### PR TITLE
Properly handle multiple blocks with same name in a single file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ html-coverage:
 	@sh ./scripts/coverage.sh --html
 
 build:
+	go generate -x ./...
 	go build
 
 install:

--- a/config/config.go
+++ b/config/config.go
@@ -136,7 +136,15 @@ func (tcf *TerragruntConfigFile) convertToTerragruntConfig(terragruntOptions *op
 	tcf.PreHooks.init(tcf)
 	tcf.PostHooks.init(tcf)
 	err = tcf.RunConditions.init(tcf.options)
-	return &tcf.TerragruntConfig, err
+
+	if tcf.Include != nil {
+		return &tcf.TerragruntConfig, err
+	}
+	// If the newly loaded configuration file is not to be merged, we force the merge
+	// process to ensure that duplicated elements will be properly processed
+	newConfig := &TerragruntConfig{options: tcf.options}
+	newConfig.mergeIncludedConfig(tcf.TerragruntConfig, terragruntOptions)
+	return newConfig, err
 }
 
 // GetSourceFolder resolves remote source and returns the local temporary folder
@@ -456,8 +464,7 @@ func parseConfigString(configString string, terragruntOptions *options.Terragrun
 		return
 	}
 
-	config, err = terragruntConfigFile.convertToTerragruntConfig(terragruntOptions)
-	if err != nil {
+	if config, err = terragruntConfigFile.convertToTerragruntConfig(terragruntOptions); err != nil {
 		return
 	}
 	terragruntOptions.Logger.Infof("Loaded configuration\n%v", color.GreenString(fmt.Sprint(terragruntConfigFile)))

--- a/config/config.go
+++ b/config/config.go
@@ -137,14 +137,14 @@ func (tcf *TerragruntConfigFile) convertToTerragruntConfig(terragruntOptions *op
 	tcf.PostHooks.init(tcf)
 	err = tcf.RunConditions.init(tcf.options)
 
-	if tcf.Include != nil {
-		return &tcf.TerragruntConfig, err
+	if tcf.Include == nil {
+		// If the newly loaded configuration file is not to be merged, we force the merge
+		// process to ensure that duplicated elements will be properly processed
+		newConfig := &TerragruntConfig{options: tcf.options}
+		newConfig.mergeIncludedConfig(tcf.TerragruntConfig, terragruntOptions)
+		return newConfig, err
 	}
-	// If the newly loaded configuration file is not to be merged, we force the merge
-	// process to ensure that duplicated elements will be properly processed
-	newConfig := &TerragruntConfig{options: tcf.options}
-	newConfig.mergeIncludedConfig(tcf.TerragruntConfig, terragruntOptions)
-	return newConfig, err
+	return &tcf.TerragruntConfig, err
 }
 
 // GetSourceFolder resolves remote source and returns the local temporary folder

--- a/config/extension_base_list.go
+++ b/config/extension_base_list.go
@@ -41,7 +41,7 @@ func (list *GenericItemList) merge(imported GenericItemList, mode mergeMode, arg
 	// Check if there are duplicated elements in the imported list
 	indexImported := make(map[string]int, len(*list))
 	for i, item := range imported {
-		indexImported[IImportVariables(&item).id()] = i
+		indexImported[IGenericItem(&item).id()] = i
 	}
 
 	// Create a list of the hooks that should be added to the list

--- a/config/extension_base_list.go
+++ b/config/extension_base_list.go
@@ -28,12 +28,9 @@ func (list GenericItemList) init(config *TerragruntConfigFile) {
 func (list *GenericItemList) merge(imported GenericItemList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IGenericItem(&(*list)[0]).logger().Debugf
+	log := IGenericItem(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -41,19 +38,34 @@ func (list *GenericItemList) merge(imported GenericItemList, mode mergeMode, arg
 		index[IGenericItem(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(GenericItemList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IGenericItem(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/extension_extra_args.go
+++ b/config/extension_extra_args.go
@@ -60,7 +60,7 @@ func (list TerraformExtraArgumentsList) Filter(source string) (result []string, 
 	cmd := util.IndexOrDefault(terragruntOptions.TerraformCliArgs, 0, "")
 
 	for _, arg := range list.Enabled() {
-		arg.logger().Debugf("Processing arg %s", arg.id())
+		arg.logger().Infof("Processing arg %s", arg.id())
 
 		if !util.ListContainsElement(arg.Commands, cmd) {
 			continue

--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -128,7 +128,7 @@ func (list ImportVariablesList) Import() (err error) {
 			// The current command is not in the list of command on which the import should be applied
 			return
 		}
-		item.logger().Debugf("Processing import variables statement %s", item.id())
+		item.logger().Infof("Processing import variables statement %s", item.id())
 
 		if item.TFVariablesFile != "" {
 			if _, ok := variablesFiles[item.TFVariablesFile]; !ok {

--- a/config/generated_approval_config.go
+++ b/config/generated_approval_config.go
@@ -27,12 +27,9 @@ func (list ApprovalConfigList) init(config *TerragruntConfigFile) {
 func (list *ApprovalConfigList) merge(imported ApprovalConfigList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IApprovalConfig(&(*list)[0]).logger().Debugf
+	log := IApprovalConfig(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ApprovalConfigList) merge(imported ApprovalConfigList, mode mergeMod
 		index[IApprovalConfig(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ApprovalConfigList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IApprovalConfig(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_approval_config.go
+++ b/config/generated_approval_config.go
@@ -40,7 +40,7 @@ func (list *ApprovalConfigList) merge(imported ApprovalConfigList, mode mergeMod
 	// Check if there are duplicated elements in the imported list
 	indexImported := make(map[string]int, len(*list))
 	for i, item := range imported {
-		indexImported[IImportVariables(&item).id()] = i
+		indexImported[IApprovalConfig(&item).id()] = i
 	}
 
 	// Create a list of the hooks that should be added to the list

--- a/config/generated_extra_args.go
+++ b/config/generated_extra_args.go
@@ -40,7 +40,7 @@ func (list *TerraformExtraArgumentsList) merge(imported TerraformExtraArgumentsL
 	// Check if there are duplicated elements in the imported list
 	indexImported := make(map[string]int, len(*list))
 	for i, item := range imported {
-		indexImported[IImportVariables(&item).id()] = i
+		indexImported[ITerraformExtraArguments(&item).id()] = i
 	}
 
 	// Create a list of the hooks that should be added to the list

--- a/config/generated_extra_args.go
+++ b/config/generated_extra_args.go
@@ -27,12 +27,9 @@ func (list TerraformExtraArgumentsList) init(config *TerragruntConfigFile) {
 func (list *TerraformExtraArgumentsList) merge(imported TerraformExtraArgumentsList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := ITerraformExtraArguments(&(*list)[0]).logger().Debugf
+	log := ITerraformExtraArguments(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *TerraformExtraArgumentsList) merge(imported TerraformExtraArgumentsL
 		index[ITerraformExtraArguments(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(TerraformExtraArgumentsList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := ITerraformExtraArguments(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_extra_command.go
+++ b/config/generated_extra_command.go
@@ -27,12 +27,9 @@ func (list ExtraCommandList) init(config *TerragruntConfigFile) {
 func (list *ExtraCommandList) merge(imported ExtraCommandList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IExtraCommand(&(*list)[0]).logger().Debugf
+	log := IExtraCommand(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ExtraCommandList) merge(imported ExtraCommandList, mode mergeMode, a
 		index[IExtraCommand(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ExtraCommandList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IExtraCommand(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_extra_command.go
+++ b/config/generated_extra_command.go
@@ -40,7 +40,7 @@ func (list *ExtraCommandList) merge(imported ExtraCommandList, mode mergeMode, a
 	// Check if there are duplicated elements in the imported list
 	indexImported := make(map[string]int, len(*list))
 	for i, item := range imported {
-		indexImported[IImportVariables(&item).id()] = i
+		indexImported[IExtraCommand(&item).id()] = i
 	}
 
 	// Create a list of the hooks that should be added to the list

--- a/config/generated_hooks.go
+++ b/config/generated_hooks.go
@@ -40,7 +40,7 @@ func (list *HookList) merge(imported HookList, mode mergeMode, argName string) {
 	// Check if there are duplicated elements in the imported list
 	indexImported := make(map[string]int, len(*list))
 	for i, item := range imported {
-		indexImported[IImportVariables(&item).id()] = i
+		indexImported[IHook(&item).id()] = i
 	}
 
 	// Create a list of the hooks that should be added to the list

--- a/config/generated_hooks.go
+++ b/config/generated_hooks.go
@@ -27,12 +27,9 @@ func (list HookList) init(config *TerragruntConfigFile) {
 func (list *HookList) merge(imported HookList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IHook(&(*list)[0]).logger().Debugf
+	log := IHook(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *HookList) merge(imported HookList, mode mergeMode, argName string) {
 		index[IHook(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(HookList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IHook(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_import_files.go
+++ b/config/generated_import_files.go
@@ -27,12 +27,9 @@ func (list ImportFilesList) init(config *TerragruntConfigFile) {
 func (list *ImportFilesList) merge(imported ImportFilesList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IImportFiles(&(*list)[0]).logger().Debugf
+	log := IImportFiles(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ImportFilesList) merge(imported ImportFilesList, mode mergeMode, arg
 		index[IImportFiles(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ImportFilesList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IImportFiles(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/config/generated_import_files.go
+++ b/config/generated_import_files.go
@@ -40,7 +40,7 @@ func (list *ImportFilesList) merge(imported ImportFilesList, mode mergeMode, arg
 	// Check if there are duplicated elements in the imported list
 	indexImported := make(map[string]int, len(*list))
 	for i, item := range imported {
-		indexImported[IImportVariables(&item).id()] = i
+		indexImported[IImportFiles(&item).id()] = i
 	}
 
 	// Create a list of the hooks that should be added to the list

--- a/config/generated_import_variables.go
+++ b/config/generated_import_variables.go
@@ -27,12 +27,9 @@ func (list ImportVariablesList) init(config *TerragruntConfigFile) {
 func (list *ImportVariablesList) merge(imported ImportVariablesList, mode mergeMode, argName string) {
 	if len(imported) == 0 {
 		return
-	} else if len(*list) == 0 {
-		*list = imported
-		return
 	}
 
-	log := IImportVariables(&(*list)[0]).logger().Debugf
+	log := IImportVariables(&(imported)[0]).logger()
 
 	// Create a map with existing elements
 	index := make(map[string]int, len(*list))
@@ -40,19 +37,34 @@ func (list *ImportVariablesList) merge(imported ImportVariablesList, mode mergeM
 		index[IImportVariables(&item).id()] = i
 	}
 
+	// Check if there are duplicated elements in the imported list
+	indexImported := make(map[string]int, len(*list))
+	for i, item := range imported {
+		indexImported[IImportVariables(&item).id()] = i
+	}
+
 	// Create a list of the hooks that should be added to the list
 	newList := make(ImportVariablesList, 0, len(imported))
-	for _, item := range imported {
+	for i, item := range imported {
 		name := IImportVariables(&item).id()
+		if pos := indexImported[name]; pos != i {
+			log.Warningf("Skipping previous definition of %s %v as it is overridden in the same file", argName, name)
+			continue
+		}
 		if pos, exist := index[name]; exist {
 			// It already exist in the list, so is is an override
 			// We remove it from its current position and add it to the list of newly added elements to keep its original declaration ordering.
 			newList = append(newList, (*list)[pos])
 			delete(index, name)
-			log("Skipping %s %v as it is overridden in the current config", argName, name)
+			log.Infof("Skipping %s %v as it is overridden in the current config", argName, name)
 			continue
 		}
 		newList = append(newList, item)
+	}
+
+	if len(*list) == 0 {
+		*list = newList
+		return
 	}
 
 	if len(index) != len(*list) {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -68,7 +68,7 @@ func PrintErrorWithStackTrace(err error) string {
 
 // Recover is a method that tries to recover from panics, and if it succeeds, calls the given onPanic function with an error that
 // explains the cause of the panic. This function should only be called from a defer statement.
-func Recover(onPanic func(cause error)) {
+func Recover(onPanic func(error)) {
 	if rec := recover(); rec != nil {
 		err, isError := rec.(error)
 		if !isError {

--- a/test/fixture-hooks/overwrite/result
+++ b/test/fixture-hooks/overwrite/result
@@ -1,0 +1,3 @@
+Pre-hook redefined
+Completed
+Post-hook

--- a/test/fixture-hooks/overwrite/terraform.tfvars
+++ b/test/fixture-hooks/overwrite/terraform.tfvars
@@ -1,0 +1,17 @@
+terragrunt {
+  extra_command "cmd" {
+    commands = ["echo Completed"]
+  }
+
+  pre_hook "hook" {
+    command = "echo Pre-hook"
+  }
+
+  post_hook "hook" {
+    command = "echo Post-hook"
+  }
+
+  pre_hook "hook" {
+    command = "echo Pre-hook redefined"
+  }
+}

--- a/test/fixture-variables/no-tf-variables/terraform.tfvars
+++ b/test/fixture-variables/no-tf-variables/terraform.tfvars
@@ -3,19 +3,19 @@ terragrunt = {
     source = "${get_current_dir()}"
   }
 
-  import_variables "test" {
+  import_variables "test1" {
     vars = [
       "hello1=123",
     ]
   }
 
-  import_variables "test" {
+  import_variables "test2" {
     optional_var_files = [
       "vars1.json",
     ]
   }
 
-  import_variables "test" {
+  import_variables "test3" {
     required_var_files = [
       "vars2.json",
     ]

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -200,3 +200,16 @@ func TestTerragruntHookWithEnvVars(t *testing.T) {
 		})
 	}
 }
+
+func TestTerragruntHookOverwrite(t *testing.T) {
+	testPath := "fixture-hooks/overwrite"
+	cleanupTerraformFolder(t, testPath)
+	tmpEnvPath := copyEnvironment(t, testPath)
+	rootPath := util.JoinPath(tmpEnvPath, testPath)
+
+	var stdout bytes.Buffer
+	runTerragruntRedirectOutput(t, fmt.Sprintf("terragrunt cmd --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), &stdout, os.Stderr)
+	content, err := ioutil.ReadFile(util.JoinPath(rootPath, "result"))
+	assert.NoError(t, err, "Reading result")
+	assert.Equal(t, string(content), stdout.String(), "Comparing result")
+}


### PR DESCRIPTION
If we declare a block with the same name, the normal behavior is to overwrite the previous definition with the latest one. That works if blocks are defined in separated files. But it did not work properly when blocks were declared in the same file.

I fixed this in the generic merge function, but that only worked if multiple blocks were declared in an included file but not for the main configuration file. So, I forced the main file to also go through the merge process (starting with an empty structure).

I also discovered a test `no-tf-variable` that was working even if it used the same block many times in the configuration. Fixing this problem caused that specific test to fail.

To ensure that we don't break existing configuration without being noticed, I added a warning when a block is overridden by another block with the same name in a file. 