### PR TITLE
Consistent file importing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/blang/semver v0.0.0-20180723201105-3c1074078d32 // indirect
 	github.com/cheekybits/genny v1.0.0
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
-	github.com/coveooss/gotemplate/v3 v3.3.6
-	github.com/coveooss/multilogger v0.4.3
+	github.com/coveooss/gotemplate/v3 v3.3.7
+	github.com/coveooss/multilogger v0.4.4
 	github.com/fatih/color v1.9.0
 	github.com/go-errors/errors v1.0.1
 	github.com/google/go-cmp v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,10 +99,12 @@ github.com/coreos/etcd v3.2.0-rc.1.0.20170908195435-80aa810309d4+incompatible/go
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/coveooss/gotemplate/v3 v3.3.6 h1:8dMkgMWGXmEbaWB29/pBoQC6RGGlFLtLuXp4K7WONc0=
-github.com/coveooss/gotemplate/v3 v3.3.6/go.mod h1:iFqyaO3yo8MGa990rBsS2bSagIR0f5pVOHUYx0qiph4=
+github.com/coveooss/gotemplate/v3 v3.3.7 h1:azkGQU2oCoHLj+3n/pFj5vqzQFo8YG8QKz/hWEOJdO8=
+github.com/coveooss/gotemplate/v3 v3.3.7/go.mod h1:iFqyaO3yo8MGa990rBsS2bSagIR0f5pVOHUYx0qiph4=
 github.com/coveooss/multilogger v0.4.3 h1:eQ1QIB/vevI3jUJPvZuf1e6fhjprUIjfwdMGM0GXbBs=
 github.com/coveooss/multilogger v0.4.3/go.mod h1:A2c+mJI+0nxjg7vnEMg00sQFGwHXqhHP73zYdYIbieQ=
+github.com/coveooss/multilogger v0.4.4 h1:6v5w0OIpMeWx33Lo0HCHhtpGrUvaeerDebozfqvzBuM=
+github.com/coveooss/multilogger v0.4.4/go.mod h1:A2c+mJI+0nxjg7vnEMg00sQFGwHXqhHP73zYdYIbieQ=
 github.com/coveord/kingpin/v2 v2.3.1 h1:GWdfhOpRbIE+5Bt/hGgDbfWkntsCC5484xFWXaor+sg=
 github.com/coveord/kingpin/v2 v2.3.1/go.mod h1:G7snIuRD09h58XUezPxWrLPuZplFdreCh6cmJZMtNUU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=


### PR DESCRIPTION
Variables from both `import_variables` and `import_files` are now only sent to local modules, not downloaded ones. Downloaded modules should have all variables passed to them as is normal in Terraform.

`import_files` used to import into downloaded modules but not `import_variables`