### PR TITLE
Allow YAML bootstrap files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -409,6 +409,11 @@ var hookWarningGiven bool
 
 // Parse the Terragrunt config contained in the given string.
 func parseConfigString(configString string, terragruntOptions *options.TerragruntOptions, include IncludeConfig, variables []hcl.Dictionary) (config *TerragruntConfig, err error) {
+	if util.ListContainsElement([]string{".yaml", ".yml", ".json"}, filepath.Ext(include.Path)) {
+		// These aren't actual configuration files
+		return
+	}
+
 	configString, err = ResolveTerragruntConfigString(configString, include, terragruntOptions)
 	if err != nil {
 		return

--- a/test/fixture-bootstrap/preboot/terraform.tfvars
+++ b/test/fixture-bootstrap/preboot/terraform.tfvars
@@ -2,6 +2,6 @@ terragrunt {
   pre_hook "print_variable" {
     on_commands = ["apply"]
     command     = "echo"
-    arguments   = ["@(my_variable)", "@(my_variable2)"]
+    arguments   = ["@(my_variable)", "@(my_variable2)", "@(my_variable3)"]
   }
 }

--- a/test/fixture-bootstrap/preboot/variables.yml
+++ b/test/fixture-bootstrap/preboot/variables.yml
@@ -1,0 +1,1 @@
+my_variable3: my_value3

--- a/test/integration_bootstrap_test.go
+++ b/test/integration_bootstrap_test.go
@@ -32,14 +32,14 @@ func TestTerragruntBootstrap(t *testing.T) {
 		{
 			name:           "Simple pre-bootstrap (adding variables)",
 			project:        "fixture-bootstrap/preboot",
-			preboot:        []string{absoluteTestPath + "/preboot/variables.json"},
-			expectedOutput: "my_value my_value2", // This is output by the hook
+			preboot:        []string{absoluteTestPath + "/preboot/variables.json", absoluteTestPath + "/preboot/variables.yml"},
+			expectedOutput: "my_value my_value2 my_value3", // This is output by the hook
 		},
 		{
 			name:           "Simple pre-bootstrap with a file prependend with file:// (Testing accepted values)",
 			project:        "fixture-bootstrap/preboot",
-			preboot:        []string{"file://" + absoluteTestPath + "/preboot/variables.json"},
-			expectedOutput: "my_value my_value2", // This is output by the hook
+			preboot:        []string{"file://" + absoluteTestPath + "/preboot/variables.json", absoluteTestPath + "/preboot/variables.yml"},
+			expectedOutput: "my_value my_value2 my_value3", // This is output by the hook
 		},
 		{
 			name:           "Complex project with a bootstrap that defines the Terraform source",

--- a/util/terraform.go
+++ b/util/terraform.go
@@ -110,6 +110,7 @@ func LoadVariablesFromSource(content, fileName, cwd string, applyTemplate bool, 
 	}
 	if strings.HasSuffix(fileName, ".yaml") || strings.HasSuffix(fileName, ".yml") {
 		err = yaml.Unmarshal([]byte(content), &result)
+		return
 	}
 
 	// We first try to read using hcl parser


### PR DESCRIPTION
They crash because HCL tries to parse them