### PR TITLE
Local files shouldn't be put into a cache

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -143,6 +143,7 @@ func (tcf *TerragruntConfigFile) convertToTerragruntConfig(terragruntOptions *op
 }
 
 // GetSourceFolder resolves remote source and returns the local temporary folder
+// If the source is local, it is directly returned
 func (tcf *TerragruntConfigFile) GetSourceFolder(name string, source string, failIfNotFound bool) (string, error) {
 	terragruntOptions := tcf.options
 

--- a/util/file.go
+++ b/util/file.go
@@ -206,7 +206,7 @@ func GetTempDownloadFolder(folders ...string) string {
 
 // GetSource gets the content of the source in a temporary folder and returns
 // the local path. The function manages a cache to avoid multiple remote calls
-// if the content has not changed
+// if the content has not changed. When given a local path, it is directly returned
 func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 	logf := func(level logrus.Level, format string, args ...interface{}) {
 		if logger != nil {
@@ -226,6 +226,11 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 		return "", err
 	}
 
+	if strings.HasPrefix(source, "file://") {
+		logf(logrus.DebugLevel, "Getting files directly (without copy) from %s", source)
+		return strings.Replace(source, "file://", "", 1), nil
+	}
+
 	logf(logrus.TraceLevel, "Fetching and locking cache for %s", source)
 	cacheDir := GetTempDownloadFolder("terragrunt-cache", EncodeBase64Sha1(source))
 	sharedMutex.Lock()
@@ -237,8 +242,6 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 		logf(logrus.TraceLevel, "Confirmed that this is an S3 object. Checking status for %s", source)
 		source = s3Object.String()
 		err = awshelper.CheckS3Status(cacheDir)
-	} else if strings.HasPrefix(source, "file://") {
-		err = fmt.Errorf("Local path always copied")
 	}
 
 	_, alreadyInCache := sharedContent[cacheDir]


### PR DESCRIPTION
In TGF, Terragrunt's cache is mounted from the host
This means that multiple runs can conflict with each other if local files are put into the cache