### PR TITLE
Fix bug when multiple nested_under are specified

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -499,6 +499,11 @@ func (conf *TerragruntConfig) loadBootConfigs(terragruntOptions *options.Terragr
 		bootstrapFile = strings.TrimSpace(bootstrapFile)
 		if bootstrapFile != "" {
 			bootstrapDir := path.Dir(bootstrapFile)
+			if strings.HasPrefix(bootstrapDir, "s3:/") {
+				// The path.Dir removes the double slash, so s3:// is not longer interpretated correctly
+				bootstrapDir = strings.Replace(bootstrapDir, "s3:/", "s3://", -1)
+			}
+
 			sourcePath, err := util.GetSource(bootstrapDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
 			if err != nil {
 				return err

--- a/options/options.go
+++ b/options/options.go
@@ -264,7 +264,7 @@ func (terragruntOptions *TerragruntOptions) ImportVariables(content string, sour
 	return results, terragrunt, nil
 }
 
-// ImportVariablesMap adds the supplied variables to the to the TerragruntOptions object
+// ImportVariablesMap adds the supplied variables to the TerragruntOptions object
 func (terragruntOptions *TerragruntOptions) ImportVariablesMap(vars map[string]interface{}, origin VariableSource) (result []hcl.Dictionary, terragrunt interface{}) {
 	result = make([]hcl.Dictionary, SetVariableResultCount)
 	for i := range result {

--- a/test/fixture-variables/multiple-nested/main.tf
+++ b/test/fixture-variables/multiple-nested/main.tf
@@ -1,0 +1,15 @@
+data "template_file" "not-flatten" {
+  template = "${var.testmap["test1"]}${var.main_testmap["test2"]}${var.local_testmap["test3"]}"
+}
+
+data "template_file" "flatten" {
+  template = "${var.testmap_test1}${var.main_testmap_test2}${var.local_testmap_test3}"
+}
+
+output "not-flatten" {
+  value = "${data.template_file.not-flatten.rendered}"
+}
+
+output "flatten" {
+  value = "${data.template_file.flatten.rendered}"
+}

--- a/test/fixture-variables/multiple-nested/terraform.tfvars
+++ b/test/fixture-variables/multiple-nested/terraform.tfvars
@@ -1,0 +1,14 @@
+terragrunt {
+  import_variables "not-flatten" {
+    required_var_files    = ["vars.json"]
+    nested_under          = ["main", "local", ""]
+    output_variables_file = "not-flatten.tf"
+  }
+
+  import_variables "flatten" {
+    required_var_files    = ["vars.json"]
+    nested_under          = ["main", "local", ""]
+    flatten_levels        = 2
+    output_variables_file = "flatten.tf"
+  }
+}

--- a/test/fixture-variables/multiple-nested/vars.json
+++ b/test/fixture-variables/multiple-nested/vars.json
@@ -1,0 +1,7 @@
+{
+    "testmap": {
+        "test1": 1,
+        "test2": 2,
+        "test3": 3
+    }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -359,7 +359,7 @@ func runTerragruntRedirectOutput(t *testing.T, command string, writer io.Writer,
 		if err, captured := errwriter.(*bytes.Buffer); captured {
 			message = "\n" + err.String()
 		}
-		t.Fatalf("Failed to run Terragrunt command '%s' due to error: %v%s", command, err, message)
+		t.Errorf("Failed to run Terragrunt command '%s' due to error: %v%s", command, err, message)
 	}
 }
 

--- a/test/integration_variables_test.go
+++ b/test/integration_variables_test.go
@@ -106,6 +106,11 @@ func TestTerragruntImportVariables(t *testing.T) {
 			expectedOutput: []string{"example = 123"},
 			args:           "--terragrunt-apply-template",
 		},
+		{
+			project:        "fixture-variables/multiple-nested",
+			expectedOutput: []string{"flatten = 123", "not-flatten = 123"},
+			args:           "--terragrunt-apply-template",
+		},
 	}
 	for _, test := range tests {
 		tt := test // tt must be unique see https://github.com/golang/go/issues/16586


### PR DESCRIPTION
- If the bootstrap file use s3://bucket syntax, it is not handled properly because the double / is removed by path.Dir
- Test should not stop immediately when they fail, this avoid us to check what was the output.