### PR TITLE
I used the wrong variable ...

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -322,8 +322,7 @@ func ParseConfigFile(terragruntOptions *options.TerragruntOptions, include Inclu
 	config = &TerragruntConfig{options: terragruntOptions}
 	if include.isIncludedBy == nil && !include.isBootstrap {
 		if err = config.loadBootConfigs(terragruntOptions, &IncludeConfig{isBootstrap: true}, terragruntOptions.PreBootConfigurationPaths); err != nil {
-			terragruntOptions.Logger.Debugf("Error parsing preboot configuration files: %v", err)
-			return
+			return nil, fmt.Errorf("Error reading preboot config file: %w", err)
 		}
 	}
 

--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -76,7 +76,7 @@ func (item *ImportVariables) loadVariables(currentVariables map[string]interface
 		}
 		item.options().ImportVariablesMap(imported, source)
 		level := *item.FlattenLevels
-		if level > 0 && len(nested) > 1 && nested == "" {
+		if level > 0 && len(item.NestedObjects) > 1 && nested == "" {
 			// If we have an empty nested value and it is not alone, we must reduce the flatted level by on for this case
 			// i.e. nested_under = ["main", "local", ""]
 			level--


### PR DESCRIPTION
The condition was impossible to reach and the result is that we flattened more deeply than we should have.

If there is an error in the preboot config, we must stop immediately.