### PR TITLE
Allow skipping templating when importing variables

### DIFF
--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -20,6 +20,7 @@ type ImportVariables struct {
 	Vars             []string          `hcl:"vars,optional"`
 	RequiredVarFiles []string          `hcl:"required_var_files,optional"`
 	OptionalVarFiles []string          `hcl:"optional_var_files,optional"`
+	NoTemplating     bool              `hcl:"no_templating_in_files,optional"`
 	Sources          []string          `hcl:"sources,optional"`
 	NestedObjects    []string          `hcl:"nested_under,optional"`
 	EnvVars          map[string]string `hcl:"env_vars,optional"`
@@ -50,7 +51,7 @@ func (item *ImportVariables) normalize() {
 
 func (item *ImportVariables) loadVariablesFromFile(file string) error {
 	item.logger().Debug("Importing ", file)
-	vars, err := item.options().LoadVariablesFromFile(file)
+	vars, err := item.options().LoadVariablesFromTemplateFile(file, !item.NoTemplating)
 	if err != nil {
 		return err
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -207,10 +207,16 @@ func (terragruntOptions TerragruntOptions) GetContext() (result collections.IDic
 
 // LoadVariablesFromFile loads variables from the file indicated by path
 func (terragruntOptions *TerragruntOptions) LoadVariablesFromFile(path string) (map[string]interface{}, error) {
+	return terragruntOptions.LoadVariablesFromTemplateFile(path, terragruntOptions.ApplyTemplate)
+}
+
+// LoadVariablesFromTemplateFile loads variables from the template file indicated by path.
+// If template is set to true, templating will be be applied on the file before reading it
+func (terragruntOptions *TerragruntOptions) LoadVariablesFromTemplateFile(path string, template bool) (map[string]interface{}, error) {
 	if !strings.Contains(path, "/") {
 		path = util.JoinPath(terragruntOptions.WorkingDir, path)
 	}
-	vars, err := util.LoadVariablesFromFile(path, terragruntOptions.WorkingDir, terragruntOptions.ApplyTemplate, terragruntOptions.GetContext())
+	vars, err := util.LoadVariablesFromFile(path, terragruntOptions.WorkingDir, template, terragruntOptions.GetContext())
 	return vars, err
 }
 

--- a/test/fixture-variables/no-templating-in-file/main.tf
+++ b/test/fixture-variables/no-templating-in-file/main.tf
@@ -1,0 +1,7 @@
+data "template_file" "example" {
+  template = "${var.hello}"
+}
+
+output "example" {
+  value = "${data.template_file.example.rendered}"
+}

--- a/test/fixture-variables/no-templating-in-file/terragrunt.hcl
+++ b/test/fixture-variables/no-templating-in-file/terragrunt.hcl
@@ -1,0 +1,14 @@
+import_variables "test" {
+  required_var_files = [
+    "vars.json",
+  ]
+  no_templating_in_files = true
+}
+
+inputs = {
+  template = "123"
+}
+
+export_variables {
+  path = "test.tf"
+}

--- a/test/fixture-variables/no-templating-in-file/vars.json
+++ b/test/fixture-variables/no-templating-in-file/vars.json
@@ -1,0 +1,3 @@
+{
+    "hello": "@template"
+}

--- a/test/fixture-variables/templating-in-file/main.tf
+++ b/test/fixture-variables/templating-in-file/main.tf
@@ -1,0 +1,7 @@
+data "template_file" "example" {
+  template = "${var.hello}"
+}
+
+output "example" {
+  value = "${data.template_file.example.rendered}"
+}

--- a/test/fixture-variables/templating-in-file/terragrunt.hcl
+++ b/test/fixture-variables/templating-in-file/terragrunt.hcl
@@ -1,0 +1,13 @@
+import_variables "test" {
+  required_var_files = [
+    "vars.json",
+  ]
+}
+
+inputs = {
+  template = "123"
+}
+
+export_variables {
+  path = "test.tf"
+}

--- a/test/fixture-variables/templating-in-file/vars.json
+++ b/test/fixture-variables/templating-in-file/vars.json
@@ -1,0 +1,3 @@
+{
+    "hello": "@template"
+}

--- a/test/integration_variables_test.go
+++ b/test/integration_variables_test.go
@@ -79,6 +79,17 @@ func TestTerragruntImportVariables(t *testing.T) {
 			expectedOutput: []string{"nested = 123"},
 			args:           "--terragrunt-apply-template",
 		},
+		{
+			project:        "fixture-variables/templating-in-file",
+			expectedOutput: []string{"example = 123"},
+			args:           "--terragrunt-apply-template",
+		},
+		// This is the same as `templating-in-file`, however `no_templating_in_files` is passed to the `import_variables` statement, so the template is not resolved
+		{
+			project:        "fixture-variables/no-templating-in-file",
+			expectedOutput: []string{"example = @template"},
+			args:           "--terragrunt-apply-template",
+		},
 	}
 	for _, test := range tests {
 		tt := test // tt must be unique see https://github.com/golang/go/issues/16586


### PR DESCRIPTION
This is useful when files have template-like values that should not be resolved
Otherwise, gotemplate throws errors