### PR TITLE
Migration script 0.11 -> 0.12

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -182,6 +182,10 @@ func CreateTerragruntCli(version string, writer io.Writer, errwriter io.Writer) 
 func runApp(cliContext *cli.Context) (finalErr error) {
 	defer errors.Recover(func(cause error) { finalErr = cause })
 
+	if cliContext.Args().First() == "0.12upgrade" {
+		return migrate(cliContext)
+	}
+
 	terragruntRunID = fmt.Sprint(xid.New())
 
 	os.Setenv(options.EnvCacheFolder, util.GetTempDownloadFolder("terragrunt-cache"))

--- a/cli/migration.go
+++ b/cli/migration.go
@@ -1,0 +1,331 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime/debug"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	gotemplateHcl "github.com/coveooss/gotemplate/v3/hcl"
+	"github.com/fatih/color"
+	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/lithammer/dedent"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/urfave/cli"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+var terragruntConfigRegex = regexp.MustCompile(`terragrunt\s*=?\s*{`)
+
+// Variable regex
+var variableRegex = regexp.MustCompile(`-VAR-(\w+)`)
+
+// https://regex101.com/r/B3grTb/1
+var variableInNameRegex = regexp.MustCompile(`((?:provider|resource|data).*){{\s*\$(\w+)\s*}}(.*)`)
+
+// https://regex101.com/r/YqfYli/1
+var variableRazorInNameRegex = regexp.MustCompile(`((?:provider|resource|data).*)@{(\w+)}(.*)`)
+
+// run_if and ignore_if are now attributes, not blocks
+var runIfRegex = regexp.MustCompile(`run_if\s*{`)
+var ignoreIfRegex = regexp.MustCompile(`ignore_if\s*{`)
+
+func migrate(cliContext *cli.Context) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("stacktrace from panic: \n" + string(debug.Stack()))
+		}
+	}()
+
+	app := kingpin.New("terragrunt 0.12upgrade", "Upgrade your Terraform files from the format used in Teraform 0.11 to the one used in 0.12")
+	workingDirectory, _ := os.Getwd()
+	targetDirectory := app.Flag("target-directory", "Where your Terraform files are located").Short('t').Default(workingDirectory).String()
+	write := app.Flag("write", "Write the changes to your files. Otherwise, display a diff").Short('w').Bool()
+	app.Flag("terragrunt-logging-level", "").String()
+	kingpin.MustParse(app.Parse(cliContext.Args()[1:]))
+
+	// Keep a copy of the original files (for a diff at the end)
+	copyOfOriginalsDir, err := copyToTemporaryDirectory("origin-copy", *targetDirectory)
+	defer os.RemoveAll(copyOfOriginalsDir)
+	if err != nil {
+		return err
+	}
+
+	// If write is not set, do the work in a temp dir
+	if write == nil || !*write {
+		tempMigrationDir, err := copyToTemporaryDirectory("migration", *targetDirectory)
+		defer os.RemoveAll(tempMigrationDir)
+		if err != nil {
+			return err
+		}
+
+		*targetDirectory = tempMigrationDir
+	}
+
+	// 1. Rewrite gotemplate -VAR-<variable> to GOVAR_<variable>_ENDVAR
+	if err := forEachFile(*targetDirectory, func(fullPath, relativePath string) error {
+		content, err := util.ReadFileAsString(fullPath)
+		if err != nil {
+			return err
+		}
+		content = variableRegex.ReplaceAllString(content, "GOVAR_${1}_ENDVAR")
+		content = variableInNameRegex.ReplaceAllString(content, "${1}GOVAR_${2}_ENDVAR${3}")
+		content = variableRazorInNameRegex.ReplaceAllString(content, "${1}GOVAR_${2}_ENDVAR${3}")
+		return ioutil.WriteFile(fullPath, []byte(content), 0777)
+	}); err != nil {
+		return err
+	}
+
+	// 2. Run terraform 0.12upgrade
+	if err := forEachFolder(*targetDirectory, func(path string) error {
+		filesInDir, err := ioutil.ReadDir(path)
+		if err != nil {
+			return err
+		}
+		for _, fileInDir := range filesInDir {
+			if strings.HasSuffix(fileInDir.Name(), ".tf") {
+				command := exec.Command("terraform", "0.12upgrade", "-yes")
+				command.Dir = path
+				command.Env = []string{"TF_LOG=DEBUG"}
+				if output, err := command.CombinedOutput(); err != nil {
+					fmt.Println(string(output))
+					return fmt.Errorf("Error in path %s: %v", path, err)
+				}
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// 3. Rewrite Terragrunt files from terraform.tfvars to terragrunt.hcl
+	if err := forEachFile(*targetDirectory, migrateConfigurationFile); err != nil {
+		return err
+	}
+
+	// 4. Remove flattened variables
+	allProjects := []string{"infra/*"}
+	if err := forEachFile(*targetDirectory, func(fullPath, relativePath string) error {
+		if strings.HasSuffix(fullPath, "terragrunt.hcl") {
+			var configFileMap map[string]interface{}
+			configFile, err := ioutil.ReadFile(fullPath)
+			if err != nil {
+				return err
+			}
+			if err := gotemplateHcl.Unmarshal(configFile, &configFileMap); err != nil {
+				return err
+			}
+
+			if inputs, ok := configFileMap["inputs"]; ok {
+				inputsMap := inputs.(map[string]interface{})
+				if projects, ok := inputsMap["import_projects"]; ok {
+					projectsList := projects.([]interface{})
+					for _, project := range projectsList {
+						if value, ok := project.(string); ok {
+							allProjects = util.RemoveDuplicatesFromListKeepFirst(append(allProjects, value))
+						}
+					}
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	flattenedVariablesReplacements := getAllFlattenedReplacementsFromImportedProjects(allProjects)
+	if err := forEachFile(*targetDirectory, func(fullPath, relativePath string) error {
+		originalContent, err := util.ReadFileAsString(fullPath)
+		if err != nil {
+			return err
+		}
+		var content string = originalContent
+		for toReplace, replacement := range flattenedVariablesReplacements {
+			content = strings.ReplaceAll(content, toReplace, replacement)
+		}
+		if content != originalContent {
+			return util.WriteFileWithSamePermissions(fullPath, fullPath, []byte(content))
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Print diffs for all files that were modified
+	// Also delete "versions.tf" files written by the previous step
+	if err := forEachFile(*targetDirectory, func(fullPath, relativePath string) error {
+		originPath := relativePath
+		if strings.HasSuffix(fullPath, "terragrunt.hcl") {
+			originPath = filepath.Join(filepath.Dir(relativePath), "terraform.tfvars")
+		}
+		originContent, err := util.ReadFileAsString(filepath.Join(copyOfOriginalsDir, originPath))
+		if err != nil && strings.HasSuffix(originPath, "versions.tf") {
+			// delete versions.tf files
+			return os.Remove(fullPath)
+		} else if err != nil {
+			return err
+		}
+		newContent, err := util.ReadFileAsString(fullPath)
+		if err != nil {
+			return err
+		}
+		printFileDiff(originPath, originContent, relativePath, newContent)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// * Turns terraform.tfvars files into terragrunt.hcl
+// * Adds equal sign to run_condition's `run_if` and `ignore_if` statements
+func migrateConfigurationFile(fullPath, relativePath string) error {
+	if !strings.HasSuffix(fullPath, "terraform.tfvars") {
+		return nil
+	}
+
+	content, err := util.ReadFileAsString(fullPath)
+	if err != nil {
+		return err
+	}
+	terragruntStatement := terragruntConfigRegex.FindStringIndex(content)
+
+	newContent := ""
+	if terragruntStatement != nil {
+		terragruntConfigDefinitionStart, terragruntBlockStart := terragruntStatement[0], terragruntStatement[1]
+
+		// Find terragrunt block end
+		index := terragruntBlockStart
+		countOpen, countClose := 1, 0
+		for countOpen != countClose {
+			if content[index] == '{' {
+				countOpen++
+			} else if content[index] == '}' {
+				countClose++
+			}
+			index++
+		}
+		terragruntBlockEnd := index
+		newContent = strings.TrimSpace(dedent.Dedent(content[terragruntBlockStart : terragruntBlockEnd-1]))
+		content = content[:terragruntConfigDefinitionStart] + content[terragruntBlockEnd:]
+	}
+
+	var inputVariables map[string]interface{}
+	if err := gotemplateHcl.Unmarshal([]byte(content), &inputVariables); err != nil {
+		return fmt.Errorf("Error unmarshalling with gotemplate: %v", err)
+	}
+	if len(inputVariables) > 0 {
+		inputVariablesMarshalled, err := gotemplateHcl.MarshalTFVarsIndent(map[string]interface{}{"inputs": inputVariables}, "  ", "  ")
+		if err != nil {
+			return fmt.Errorf("error marshalling input variables: %v", err)
+		}
+		newContent += "\n" + string(inputVariablesMarshalled)
+	}
+
+	// Add equal sign to run_if and ignore_if
+	newContent = runIfRegex.ReplaceAllString(newContent, "run_if = {")
+	newContent = ignoreIfRegex.ReplaceAllString(newContent, "ignore_if = {")
+
+	newPath := filepath.Join(filepath.Dir(fullPath), "terragrunt.hcl")
+	if err := ioutil.WriteFile(newPath, []byte(newContent), 0777); err != nil {
+		return err
+	}
+
+	return os.Remove(fullPath)
+}
+
+func forEachFile(directory string, action func(fullPath, relativePath string) error) error {
+	return filepath.Walk(directory, func(walkPath string, info os.FileInfo, err error) error {
+		if info == nil || info.IsDir() || err != nil {
+			return nil
+		}
+		if strings.HasPrefix(info.Name(), ".") {
+			return nil
+		}
+		relativePath, _ := filepath.Rel(directory, walkPath)
+		return action(walkPath, relativePath)
+	})
+}
+
+func forEachFolder(directory string, action func(fullPath string) error) error {
+	return filepath.Walk(directory, func(walkPath string, info os.FileInfo, err error) error {
+		if !info.IsDir() || err != nil {
+			return nil
+		}
+		return action(walkPath)
+	})
+}
+
+func printFileDiff(oldFilename, oldContent, newFilename, newContent string) {
+	titleStyle := color.New(color.Bold, color.Underline)
+	if oldFilename != newFilename {
+		filenameDmp := diffmatchpatch.New()
+		filenameDiffs := filenameDmp.DiffCleanupSemantic(filenameDmp.DiffMain(color.YellowString(oldFilename), color.YellowString(newFilename), false))
+		title := filenameDmp.DiffPrettyText(filenameDiffs)
+		titleStyle.Println(title)
+	} else if newContent != oldContent {
+		title := color.YellowString(oldFilename)
+		titleStyle.Println(title)
+	}
+
+	if newContent != oldContent {
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffCleanupSemantic(dmp.DiffMain(oldContent, newContent, false))
+		fmt.Println(dmp.DiffPrettyText(diffs))
+
+	}
+	fmt.Println()
+}
+
+func copyToTemporaryDirectory(name string, source string) (string, error) {
+	tempDir, err := ioutil.TempDir("", "terragrunt-0.12-"+name)
+	if err != nil {
+		return "", err
+	}
+	return tempDir, util.CopyFolderContents(source, tempDir)
+}
+
+func getAllFlattenedReplacementsFromImportedProjects(importedProjects []string) map[string]string {
+	replacements := map[string]string{}
+	sess := session.Must(session.NewSession())
+	svc := s3.New(sess)
+	if err := svc.ListObjectsPages(&s3.ListObjectsInput{
+		Bucket: aws.String("coveo-terraform-outputs-us-east-1"),
+	}, func(p *s3.ListObjectsOutput, last bool) (shouldContinue bool) {
+		for _, obj := range p.Contents {
+			// Format of keys is env/region/project/subproject.tfvars
+			key := *obj.Key
+			if strings.HasSuffix(key, ".tfvars") {
+				for _, importedProject := range importedProjects {
+					splitImported := strings.Split(importedProject, "/")
+					project := splitImported[0]
+					subproject := ""
+					if len(splitImported) == 2 {
+						if value := splitImported[1]; value != "*" {
+							subproject = value
+						}
+					}
+
+					splitKey := strings.Split(key, "/")
+					objProject := splitKey[2]
+					objSubproject := strings.Split(splitKey[3], ".")[0]
+					if objProject == project && (subproject == "" || subproject == objSubproject) {
+						replacements[objProject+"_"+objSubproject+"_"] = objProject + "." + objSubproject + "."
+					}
+				}
+			}
+		}
+		return true
+	}); err != nil {
+		panic(err)
+	}
+	return replacements
+}

--- a/cli/migration_test.go
+++ b/cli/migration_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/coveooss/gotemplate/v3/hcl"
+	"github.com/lithammer/dedent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMigrateConfigurationFile(t *testing.T) {
+	t.Parallel()
+
+	type list = hcl.List
+	type vars = map[string]interface{}
+	tests := []struct {
+		name     string
+		initial  string
+		expected string
+	}{
+		{
+			name:     "Empty file",
+			initial:  "",
+			expected: "",
+		},
+		{
+			name:     "Empty config",
+			initial:  "terragrunt {}",
+			expected: "",
+		},
+		{
+			name: "Empty config multiline",
+			initial: `terragrunt {
+
+			}`,
+			expected: "",
+		},
+		{
+			name: "Empty config multiline with equal",
+			initial: `terragrunt = {
+
+			}`,
+			expected: "",
+		},
+		{
+			name: "Simple case",
+			initial: `
+			terragrunt = {
+				post_hook "post_hook_1" {
+					on_commands = ["apply", "plan"]
+					command     = "exit 2"
+				}
+
+				post_hook "post_hook_2" {
+					on_commands = ["apply", "plan"]
+					command     = "touch test.out"
+				}
+			}`,
+			expected: `
+			post_hook "post_hook_1" {
+				on_commands = ["apply", "plan"]
+				command     = "exit 2"
+			}
+
+			post_hook "post_hook_2" {
+				on_commands = ["apply", "plan"]
+				command     = "touch test.out"
+			}`,
+		},
+		{
+			name: "With Variables",
+			initial: `
+			before = {
+				variable = {
+					inner = "text"
+				}
+			}
+
+			terragrunt{
+				import_variables "test" {
+					required_var_files = [
+						"vars.json",
+					]
+
+					output_variables_file = "test.tf"
+				}
+			}
+
+			after = [
+				{
+					inner = "text"
+				},
+				{
+					inner = "text2"
+				}
+			]`,
+			expected: `
+			import_variables "test" {
+				required_var_files = [
+					"vars.json",
+				]
+
+				output_variables_file = "test.tf"
+			}
+			inputs = {
+				after = [
+					{
+						inner = "text"
+					},
+					{
+						inner = "text2"
+					},
+				]
+
+				before = {
+					variable = {
+						inner = "text"
+					}
+				}
+			}`,
+		},
+		{
+			name: "",
+			initial: `
+			project = "spinnaker"
+
+			namespace = "spinnaker"
+			
+			source_path = "../modules"
+			
+			terragrunt = {
+			  assume_role = "${var.deploy_role_ops}"
+			}
+			`,
+			expected: `
+			assume_role = "${var.deploy_role_ops}"
+			inputs = {
+				project = "spinnaker"
+				namespace = "spinnaker"
+				source_path = "../modules"
+			}
+			`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			configDir, _ := ioutil.TempDir("", "TerragruntTestMigrateConfigurationFile")
+			configFile := path.Join(configDir, "terraform.tfvars")
+			resultFile := path.Join(configDir, "terragrunt.hcl")
+			defer os.RemoveAll(configDir)
+
+			// Initial config
+			ioutil.WriteFile(configFile, []byte(dedent.Dedent(tt.initial)), 0777)
+
+			// Migrate (No error)
+			assert.Nil(t, migrateConfigurationFile(configFile, "terraform.tfvars"))
+
+			// Verify content
+			result, _ := ioutil.ReadFile(resultFile)
+			var (
+				expectedParsed interface{}
+				resultParsed   interface{}
+			)
+			hcl.Unmarshal([]byte(tt.expected), &expectedParsed)
+			hcl.Unmarshal(result, &resultParsed)
+			assert.Equal(t, expectedParsed, resultParsed)
+
+			// Verify that the old config file does not exist
+			_, err := os.Stat(configFile)
+			assert.Truef(t, os.IsNotExist(err), "%s should not exist", configFile)
+		})
+	}
+
+}

--- a/cli/migration_test.go
+++ b/cli/migration_test.go
@@ -14,7 +14,6 @@ import (
 func TestMigrateConfigurationFile(t *testing.T) {
 	t.Parallel()
 
-	type list = hcl.List
 	type vars = map[string]interface{}
 	tests := []struct {
 		name     string

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,12 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl/v2 v2.3.0
 	github.com/hashicorp/terraform v0.12.21
+	github.com/lithammer/dedent v1.1.0
 	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2 // indirect
 	github.com/mattn/go-zglob v0.0.1
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/rs/xid v1.2.1
+	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
 	github.com/ulikunitz/xz v0.5.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,6 +331,8 @@ github.com/likexian/gokit v0.20.15/go.mod h1:kn+nTv3tqh6yhor9BC4Lfiu58SmH8NmQ2Pm
 github.com/likexian/simplejson-go v0.0.0-20190409170913-40473a74d76d/go.mod h1:Typ1BfnATYtZ/+/shXfFYLrovhFyuKvzwrdOnIDHlmg=
 github.com/likexian/simplejson-go v0.0.0-20190419151922-c1f9f0b4f084/go.mod h1:U4O1vIJvIKwbMZKUJ62lppfdvkCdVd2nfMimHK81eec=
 github.com/likexian/simplejson-go v0.0.0-20190502021454-d8787b4bfa0b/go.mod h1:3BWwtmKP9cXWwYCr5bkoVDEfLywacOv0s06OBEDpyt8=
+github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
+github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82 h1:wnfcqULT+N2seWf6y4yHzmi7GD2kNx4Ute0qArktD48=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54tfGmO3NKssKveTEFFzH8C/akrSOy/iW9qEAUDV84=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9 h1:SmVbOZFWAlyQshuMfOkiAx1f5oUTsOGG5IXplAEYeeM=

--- a/util/terraform.go
+++ b/util/terraform.go
@@ -22,7 +22,11 @@ func LoadDefaultValues(folder string) (importedVariables map[string]interface{},
 	var terraformConfig *configs.Module
 	parser := configs.NewParser(nil)
 	if terraformConfig, err = parser.LoadConfigDir(folder); err != nil && err.(hcl2.Diagnostics).HasErrors() {
-		return map[string]interface{}{}, nil, fmt.Errorf("caught error while trying to load default variable values from %s: %v", folder, err)
+		errors := []string{}
+		for _, err := range err.(hcl2.Diagnostics).Errs() {
+			errors = append(errors, " - "+err.Error())
+		}
+		return map[string]interface{}{}, nil, fmt.Errorf("caught errors while trying to load default variable values from %s:\n%v", folder, strings.Join(errors, "\n"))
 	}
 	importedVariables, err = getTerraformVariableValues(terraformConfig, false)
 	return importedVariables, terraformConfig.Variables, err


### PR DESCRIPTION
1. Migrate -VAR- variables to GOVAR_<variable>_ENDVAR. Terraform 0.12 doesn't support variables with dashes in them
2. Run terraform 0.12upgrade command in all folders with .tf files
3. Rewrite terragrunt config files
4. Replace flattened variables with nested. Ex: project_sub_variable -> project.sub.variable
5. Print diffs or rewrite files