### PR TITLE
Add a function to set global variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 
 Terragrunt is a thin wrapper for [Terraform](https://www.terraform.io/) that provides extra tools for keeping your Terraform configurations DRY, working with multiple Terraform modules, and managing remote state.
 
+All files process by terragrunt (config files or terraform files) are pre-processed by go template.
+
+## set_global_variable
+
+`set_global_variable(key, value)` allows users to add/modify a global variable. Example:
+
+```hcl
+# @set_global_variable("Today", now().Weekday())                     // Used as Razor function
+# {{ set_global_variable "Tomorrow" (now.AddDate 0 0 1).Weekday }}   // Used as go template function
+```
+
 ## Quick start
 
 1. [Install Terraform](https://www.terraform.io/intro/getting-started/install.html).
@@ -1302,7 +1313,6 @@ Terragrunt allows you to use [Terraform interpolation syntax](https://www.terraf
 * [get_terraform_commands_that_need_input()](#get_terraform_commands_that_need_input)
 * [get_terraform_commands_that_need_locking()](#get_terraform_commands_that_need_locking)
 * [get_aws_account_id()](#get_aws_account_id)
-* [set_global_variable()](#set_global_variable)
 
 #### find_in_parent_folders
 
@@ -1666,16 +1676,6 @@ terragrunt = {
     arguments = ["-var-file=${get_aws_account_id()}.tfvars"]
   }
 }
-```
-
-#### set_global_variable
-
-`set_global_variable(key, value)` allows users to add/modify a global variable. Example:
-
-```hcl
-# @set_global_variable("Today", now().Weekday())                     // Used as Razor function
-# {{ set_global_variable "Tomorrow" (now.AddDate 0 0 1).Weekday }}   // Used as go template function
-# ${set_global_variable("Key", "Value")}                             // Used as HCL interpolation function
 ```
 
 ### CLI Options

--- a/README.md
+++ b/README.md
@@ -1302,6 +1302,7 @@ Terragrunt allows you to use [Terraform interpolation syntax](https://www.terraf
 * [get_terraform_commands_that_need_input()](#get_terraform_commands_that_need_input)
 * [get_terraform_commands_that_need_locking()](#get_terraform_commands_that_need_locking)
 * [get_aws_account_id()](#get_aws_account_id)
+* [set_global_variable()](#set_global_variable)
 
 #### find_in_parent_folders
 
@@ -1665,6 +1666,16 @@ terragrunt = {
     arguments = ["-var-file=${get_aws_account_id()}.tfvars"]
   }
 }
+```
+
+#### set_global_variable
+
+`set_global_variable(key, value)` allows users to add/modify a global variable. Example:
+
+```hcl
+# @set_global_variable("Today", now().Weekday())                     // Used as Razor function
+# {{ set_global_variable "Tomorrow" (now.AddDate 0 0 1).Weekday }}   // Used as go template function
+# ${set_global_variable("Key", "Value")}                             // Used as HCL interpolation function
 ```
 
 ### CLI Options

--- a/cli/args.go
+++ b/cli/args.go
@@ -158,6 +158,10 @@ func filterVarsAndVarFiles(command string, terragruntOptions *options.Terragrunt
 
 	for i := 0; i < len(args); i++ {
 		if matches, match := reutils.MultiMatch(args[i], reVarFile); match >= 0 {
+			if strings.HasPrefix(matches[""], "--") {
+				// If the user specified is argument with --var or --var-file, we uniformize it to -var/-var-file
+				args[i] = args[i][1:]
+			}
 			if matches["value"] == "" && i+1 < len(args) {
 				// The value is specified in the next argument
 				matches["value"] = args[i+1]

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -176,7 +176,6 @@ func (context *resolveContext) executeTerragruntHelperFunction(functionName stri
 			"get_parent_tfvars_dir":                    (*resolveContext).getParentDir,
 			"get_aws_account_id":                       (*resolveContext).getAWSAccountID,
 			"save_variables":                           (*resolveContext).saveVariables,
-			"set_global_variable":                      (*resolveContext).setGlobalVariable,
 			"get_terraform_commands_that_need_vars":    TerraformCommandWithVarFile,
 			"get_terraform_commands_that_need_locking": TerraformCommandWithLockTimeout,
 			"get_terraform_commands_that_need_input":   TerraformCommandWithInput,

--- a/config/config_helpers.go
+++ b/config/config_helpers.go
@@ -147,6 +147,7 @@ func (context *resolveContext) getHelperFunctions() map[string]interface{} {
 		"get_parent_dir":                           context.getParentDir,
 		"get_parent_tfvars_dir":                    context.getParentDir,
 		"get_aws_account_id":                       context.getAWSAccountID,
+		"set_global_variable":                      context.setGlobalVariable,
 		"get_terraform_commands_that_need_vars":    func() interface{} { return collections.AsList(TerraformCommandWithVarFile) },
 		"get_terraform_commands_that_need_locking": func() interface{} { return collections.AsList(TerraformCommandWithLockTimeout) },
 		"get_terraform_commands_that_need_input":   func() interface{} { return collections.AsList(TerraformCommandWithInput) },
@@ -175,6 +176,7 @@ func (context *resolveContext) executeTerragruntHelperFunction(functionName stri
 			"get_parent_tfvars_dir":                    (*resolveContext).getParentDir,
 			"get_aws_account_id":                       (*resolveContext).getAWSAccountID,
 			"save_variables":                           (*resolveContext).saveVariables,
+			"set_global_variable":                      (*resolveContext).setGlobalVariable,
 			"get_terraform_commands_that_need_vars":    TerraformCommandWithVarFile,
 			"get_terraform_commands_that_need_locking": TerraformCommandWithLockTimeout,
 			"get_terraform_commands_that_need_input":   TerraformCommandWithInput,
@@ -573,6 +575,17 @@ func (context *resolveContext) getAWSAccountID() (interface{}, error) {
 	}
 
 	return *identity.Account, nil
+}
+
+func (context *resolveContext) setGlobalVariable(key string, value interface{}) (string, error) {
+	if key == "" {
+		for key, value := range collections.AsDictionary(value).AsMap() {
+			context.options.SetVariable(key, value, options.FunctionOverwrite)
+		}
+	} else {
+		context.options.SetVariable(key, value, options.FunctionOverwrite)
+	}
+	return "", nil
 }
 
 func (context *resolveContext) getParameters(regex *regexp.Regexp) ([]string, error) {

--- a/options/generated_variable_source.go
+++ b/options/generated_variable_source.go
@@ -16,11 +16,12 @@ func _() {
 	_ = x[VarParameter-5]
 	_ = x[Environment-6]
 	_ = x[VarParameterExplicit-7]
+	_ = x[FunctionOverwrite-8]
 }
 
-const _VariableSource_name = "UndefinedSourceDefaultConfigVarFileVarFileVarFileExplicitVarParameterEnvironmentVarParameterExplicit"
+const _VariableSource_name = "UndefinedSourceDefaultConfigVarFileVarFileVarFileExplicitVarParameterEnvironmentVarParameterExplicitFunctionOverwrite"
 
-var _VariableSource_index = [...]uint8{0, 15, 22, 35, 42, 57, 69, 80, 100}
+var _VariableSource_index = [...]uint8{0, 15, 22, 35, 42, 57, 69, 80, 100, 117}
 
 func (i VariableSource) String() string {
 	if i >= VariableSource(len(_VariableSource_index)-1) {

--- a/options/options.go
+++ b/options/options.go
@@ -400,6 +400,17 @@ func (terragruntOptions *TerragruntOptions) SetVariable(key string, value interf
 			return IgnoredVariable
 		}
 		status := NewVariable
+		if source > target.Source && target.Source == VarParameterExplicit {
+			// The user has redefined a variable passed as argument, so we have to replace it
+			args := terragruntOptions.TerraformCliArgs
+			for i := range args {
+				if args[i] == "-var" {
+					if argKey, _ := collections.Split2(args[i+1], "="); argKey == key {
+						args[i+1] = fmt.Sprintf("%s=%v", key, value)
+					}
+				}
+			}
+		}
 		if target.Source != UndefinedSource {
 			terragruntOptions.Logger.Debugf("Overwriting value for %s with %v", key, value)
 			status = IgnoredVariable
@@ -430,6 +441,7 @@ const (
 	VarParameter
 	Environment
 	VarParameterExplicit
+	FunctionOverwrite
 )
 
 //go:generate stringer -type=VariableSource -output generated_variable_source.go

--- a/test/fixture-variables/overridden-explicit-variable/main.tf
+++ b/test/fixture-variables/overridden-explicit-variable/main.tf
@@ -1,0 +1,5 @@
+variable "region" {}
+
+output "example" {
+  value = "${var.region}"
+}

--- a/test/fixture-variables/overridden-explicit-variable/terraform.tfvars
+++ b/test/fixture-variables/overridden-explicit-variable/terraform.tfvars
@@ -1,0 +1,6 @@
+terragrunt = {
+}
+
+region = "us-east-1"
+
+#! {{ set_global_variable "region" "us-west-2" }}

--- a/test/integration_variables_test.go
+++ b/test/integration_variables_test.go
@@ -122,6 +122,11 @@ func TestTerragruntImportVariables(t *testing.T) {
 			expectedOutput: []string{"example = @template"},
 			args:           "--terragrunt-apply-template",
 		},
+		{
+			project:        "fixture-variables/overridden-explicit-variable",
+			expectedOutput: []string{"example = us-west-2"},
+			args:           "--terragrunt-apply-template -var region=us-east-1",
+		},
 	}
 	for _, test := range tests {
 		tt := test // tt must be unique see https://github.com/golang/go/issues/16586


### PR DESCRIPTION
While processing configuration files, it was not possible to change the actual value of a global variable since the context is reset between each file.

Terragrunt now add the possibility to permanently change or add a global variable during the evaluation process.