### PR TITLE
More robust file download

### DIFF
--- a/cli/migration.go
+++ b/cli/migration.go
@@ -78,7 +78,7 @@ func migrate(cliContext *cli.Context) (err error) {
 		content = variableRegex.ReplaceAllString(content, "GOVAR_${1}_ENDVAR")
 		content = variableInNameRegex.ReplaceAllString(content, "${1}GOVAR_${2}_ENDVAR${3}")
 		content = variableRazorInNameRegex.ReplaceAllString(content, "${1}GOVAR_${2}_ENDVAR${3}")
-		return ioutil.WriteFile(fullPath, []byte(content), 0777)
+		return ioutil.WriteFile(fullPath, []byte(content), 0666)
 	}); err != nil {
 		return err
 	}
@@ -243,10 +243,10 @@ func migrateConfigurationFile(fullPath, relativePath string) error {
 	newContent = ignoreIfRegex.ReplaceAllString(newContent, "ignore_if = {")
 
 	newPath := filepath.Join(filepath.Dir(fullPath), "terragrunt.hcl")
-	if err := ioutil.WriteFile(newPath, []byte(newContent), 0777); err != nil {
+	if err := ioutil.WriteFile(newPath, []byte(newContent), 0666); err != nil {
 		return err
 	}
-	if err := os.Chmod(newPath, 0777); err != nil {
+	if err := os.Chmod(newPath, 0666); err != nil {
 		return err
 	}
 

--- a/util/file.go
+++ b/util/file.go
@@ -220,10 +220,10 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 		if err != nil {
 			logf(logrus.WarnLevel, "Downloading %s failed. Retrying in 2 seconds. Err: %v", source, err)
 			time.Sleep(2 * time.Second)
+			delete(sharedContent, result)
 			if result != "" && FileExists(result) {
 				// Download failed but the dir exists, let's delete it
 				logf(logrus.WarnLevel, "Deleting cache dir for %s: %s", source, result)
-				delete(sharedContent, result)
 				if removeErr := os.RemoveAll(result); removeErr != nil {
 					logf(logrus.WarnLevel, "Failed to delete cache dir %s: %v", result, removeErr)
 				}

--- a/util/file.go
+++ b/util/file.go
@@ -213,6 +213,31 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 		}
 	}
 
+	var result string
+	if finalErr := try.Do(func(attempt int) (bool, error) {
+		var err error
+		result, err = getSource(source, pwd, logf)
+		if err != nil {
+			logf(logrus.WarnLevel, "Downloading %s failed. Retrying in 2 seconds. Err: %v", source, err)
+			time.Sleep(2 * time.Second)
+			if result != "" && FileExists(result) {
+				// Download failed but the dir exists, let's delete it
+				logf(logrus.WarnLevel, "Deleting cache dir for %s: %s", source, result)
+				delete(sharedContent, result)
+				if removeErr := os.RemoveAll(result); removeErr != nil {
+					logf(logrus.WarnLevel, "Failed to delete cache dir %s: %v", result, removeErr)
+				}
+			}
+
+		}
+		return attempt <= 3, err
+	}); finalErr != nil {
+		return "", fmt.Errorf("%v while copying source from %s", finalErr, source)
+	}
+	return result, nil
+}
+
+func getSource(source, pwd string, logf func(level logrus.Level, format string, args ...interface{})) (string, error) {
 	logf(logrus.TraceLevel, "Converting S3 path to be compatible with getter for %s", source)
 	source, err := awshelper.ConvertS3Path(source)
 	if err != nil {
@@ -259,13 +284,8 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 				}
 			}
 
-			err = try.Do(func(attempt int) (bool, error) {
-				err := GetCopy(cacheDir, source)
-				logf(logrus.TraceLevel, "Tried to fetch %s, attempt %d, err: %v", source, attempt, err)
-				return attempt < 3, err
-			})
-			if err != nil {
-				return "", fmt.Errorf("%v while copying source from %s", err, source)
+			if err := GetCopy(cacheDir, source); err != nil {
+				return "", fmt.Errorf("caught error while fetching files from %s: %v", source, err)
 			}
 
 			if s3Object != nil {
@@ -274,7 +294,7 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 				err = awshelper.SaveS3Status(s3Object, cacheDir)
 			}
 			if err != nil {
-				logf(logrus.WarnLevel, "%v while saving status for %s. The cache will be reset on the next fetch, even if the files haven't changed", err, source)
+				return "", fmt.Errorf("caught %v while saving status for %s", err, source)
 			}
 			logf(logrus.DebugLevel, "Files from %s successfully added to the cache at %s", source, cacheDir)
 		}


### PR DESCRIPTION
What happened is that the "The cache will be reset on the next fetch, even if the files haven't changed" warning was thrown but Terragrunt continued as if nothing while the files did not exist in the cache dir

The part that we retry (GetCopy) does not seem to actually ever fail

The fix is making the warning an error (it was before), and putting the retry around the whole block. If there are any errors, we delete the cacheDir and try the whole thing again

+ also changed 777 for 666 in the migration script