### PR TITLE
Mitigate possible errors on S3 calls

### DIFF
--- a/awshelper/config.go
+++ b/awshelper/config.go
@@ -16,6 +16,13 @@ import (
 
 var sessionCache sync.Map
 
+func clearSessionCache() {
+	sessionCache.Range(func(key interface{}, value interface{}) bool {
+		sessionCache.Delete(key)
+		return true
+	})
+}
+
 // CreateAwsSession returns an AWS session object for the given region, ensuring that the credentials are available
 func CreateAwsSession(awsRegion, awsProfile string) (*session.Session, error) {
 	awsSessionKey := awsRegion + "/" + awsProfile

--- a/awshelper/s3.go
+++ b/awshelper/s3.go
@@ -179,7 +179,8 @@ func getS3Status(info BucketInfo) (*bucketStatus, error) {
 		Key:    aws.String(info.Key),
 	})
 	if err != nil {
-		return nil, err
+		clearSessionCache()
+		return nil, fmt.Errorf("caught error while calling HeadObject on key %s of bucket %s: %v", info.Key, info.BucketName, err)
 	}
 
 	return &bucketStatus{


### PR DESCRIPTION
+ Remove the getBucketRegion call, it is not necessary for a HeadObject
+ Clear the sessionCache if we get an error, this will allow us to try again with another session
+ Add more info to the error message, it should be easier to diagnose what call failed