### PR TITLE
Do not copy the source folder while copying the launch folder

### DIFF
--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -50,7 +50,12 @@ func downloadTerraformSource(source *TerraformSource, terragruntOptions *options
 	}
 
 	terragruntOptions.Logger.Debugf("Copying files from %s into %s", terragruntOptions.WorkingDir, source.WorkingDir)
-	if err := util.CopyFolderContents(terragruntOptions.WorkingDir, source.WorkingDir); err != nil {
+	excluded := []string{}
+	if source.CanonicalSourceURL.Scheme == "file" {
+		// We exclude the local source path from the copy to avoid copying source directory twice in the temporary folder.
+		excluded = append(excluded, source.CanonicalSourceURL.Path)
+	}
+	if err := util.CopyFolderContents(terragruntOptions.WorkingDir, source.WorkingDir, excluded...); err != nil {
 		return err
 	}
 

--- a/util/file.go
+++ b/util/file.go
@@ -311,7 +311,7 @@ var sharedContent = map[string]bool{}
 
 // CopyFolderContents copies the files and folders within the source folder into the destination folder. Note that hidden files and folders
 // (those starting with a dot) will be skipped.
-func CopyFolderContents(source string, destination string) error {
+func CopyFolderContents(source, destination string, excluded ...string) error {
 	files, err := ioutil.ReadDir(source)
 	if err != nil {
 		return errors.WithStackTrace(err)
@@ -320,7 +320,9 @@ func CopyFolderContents(source string, destination string) error {
 	for _, file := range files {
 		src := filepath.Join(source, file.Name())
 		dest := filepath.Join(destination, file.Name())
-
+		if ListContainsElement(excluded, src) {
+			continue
+		}
 		if PathContainsHiddenFileOrFolder(src) {
 			continue
 		} else if file.IsDir() {


### PR DESCRIPTION
This solve a problem when the source folder is located directly under the launch folder.