### PR TITLE
Retry for all cases except if S3 dir doesn't exist

### DIFF
--- a/awshelper/s3.go
+++ b/awshelper/s3.go
@@ -142,6 +142,7 @@ func SaveS3Status(bucketInfo *BucketInfo, folder string) (err error) {
 // CheckS3Status compares the saved status with the current version of the bucket folder
 // returns true if the objects has not changed
 func CheckS3Status(sourceBucketInfo *BucketInfo, folder string) error {
+	// Check for the status of the object in S3. If it doesn't exist in S3, there's no point in reading the local/saved status
 	s3Status, err := getS3Status(*sourceBucketInfo)
 	if err != nil {
 		var awsError awserr.Error

--- a/awshelper/s3.go
+++ b/awshelper/s3.go
@@ -18,7 +18,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-var S3PathNotFoundError = errors.New("HeadObject failed on the given object")
+// ErrS3PathNotFoundError is the error that will be returned if an object doesn't exist in S3
+var ErrS3PathNotFoundError = errors.New("HeadObject failed on the given object")
 
 // CacheFile is the name of the file that hold the S3 source configuration for the folder
 const CacheFile = ".terragrunt.cache"
@@ -148,7 +149,7 @@ func CheckS3Status(sourceBucketInfo *BucketInfo, folder string) error {
 		var awsError awserr.Error
 		if errors.As(err, &awsError) {
 			if awsError.Code() == "NotFound" {
-				return fmt.Errorf("%s does not exist: %w", *sourceBucketInfo, S3PathNotFoundError)
+				return fmt.Errorf("%s does not exist: %w", *sourceBucketInfo, ErrS3PathNotFoundError)
 			}
 		}
 		return fmt.Errorf("error while reading %s: %w", *sourceBucketInfo, err)

--- a/config/config.go
+++ b/config/config.go
@@ -496,6 +496,10 @@ func (conf *TerragruntConfig) loadBootConfigs(terragruntOptions *options.Terragr
 				bootstrapDir = strings.Replace(bootstrapDir, "s3:/", "s3://", -1)
 			}
 
+			if !strings.HasSuffix(bootstrapDir, "/") {
+				bootstrapDir = bootstrapDir + "/"
+			}
+
 			sourcePath, err := util.GetSource(bootstrapDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
 			if err != nil {
 				return err

--- a/util/file.go
+++ b/util/file.go
@@ -221,6 +221,7 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 		result, err = getSource(source, pwd, logf)
 		if err != nil {
 			if attempt > 3 || errors.Is(err, awshelper.S3PathNotFoundError) {
+				// If the object doesn't exist in S3, there's no point in retrying
 				return false, err
 			}
 			logf(logrus.WarnLevel, "Downloading %s failed. Retrying in 1 second. Err: %v", source, err)
@@ -272,6 +273,8 @@ func getSource(source, pwd string, logf func(level logrus.Level, format string, 
 		source = s3Object.String()
 		err = awshelper.CheckS3Status(s3Object, cacheDir)
 		if errors.Is(err, awshelper.S3PathNotFoundError) {
+			logf(logrus.DebugLevel, "%s was not found in S3", source)
+			// If the source is not found in S3, return right away
 			return "", err
 		}
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -220,10 +220,10 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 		var err error
 		result, err = getSource(source, pwd, logf)
 		if err != nil {
-			if attempt >= 3 || errors.Is(err, os.ErrNotExist) {
+			if attempt > 3 || errors.Is(err, awshelper.S3PathNotFoundError) {
 				return false, err
 			}
-			logf(logrus.WarnLevel, "Downloading %s failed. Retrying in 2 seconds. Err: %v", source, err)
+			logf(logrus.WarnLevel, "Downloading %s failed. Retrying in 1 second. Err: %v", source, err)
 			time.Sleep(time.Second)
 			delete(sharedContent, result)
 			if result != "" && FileExists(result) {
@@ -270,12 +270,15 @@ func getSource(source, pwd string, logf func(level logrus.Level, format string, 
 	if s3Object != nil {
 		logf(logrus.TraceLevel, "Confirmed that this is an S3 object. Checking status for %s", source)
 		source = s3Object.String()
-		err = awshelper.CheckS3Status(cacheDir)
+		err = awshelper.CheckS3Status(s3Object, cacheDir)
+		if errors.Is(err, awshelper.S3PathNotFoundError) {
+			return "", err
+		}
 	}
 
 	_, alreadyInCache := sharedContent[cacheDir]
 	if !alreadyInCache || err != nil {
-		logf(logrus.DebugLevel, "Adding %s to the cache", source)
+		logf(logrus.DebugLevel, "Adding %s to the in-memory cache", source)
 		if !FileExists(cacheDir) || err != nil {
 			var reason string
 			if err != nil {

--- a/util/file.go
+++ b/util/file.go
@@ -220,7 +220,7 @@ func GetSource(source, pwd string, logger *multilogger.Logger) (string, error) {
 		var err error
 		result, err = getSource(source, pwd, logf)
 		if err != nil {
-			if attempt > 3 || errors.Is(err, awshelper.S3PathNotFoundError) {
+			if attempt > 3 || errors.Is(err, awshelper.ErrS3PathNotFoundError) {
 				// If the object doesn't exist in S3, there's no point in retrying
 				return false, err
 			}
@@ -272,7 +272,7 @@ func getSource(source, pwd string, logf func(level logrus.Level, format string, 
 		logf(logrus.TraceLevel, "Confirmed that this is an S3 object. Checking status for %s", source)
 		source = s3Object.String()
 		err = awshelper.CheckS3Status(s3Object, cacheDir)
-		if errors.Is(err, awshelper.S3PathNotFoundError) {
+		if errors.Is(err, awshelper.ErrS3PathNotFoundError) {
 			logf(logrus.DebugLevel, "%s was not found in S3", source)
 			// If the source is not found in S3, return right away
 			return "", err


### PR DESCRIPTION
That was the initial purpose but ErrNotExist was catching all errors since the temporary directory that stores downloaded files is always created

It was replaced by a HeadObject check on the S3 path. If the HeadObject returns NotFound, that means that we shouldn't try to get files