### PR TITLE
Try to get a source's metadata with slash if it doesn't have one

### DIFF
--- a/awshelper/s3.go
+++ b/awshelper/s3.go
@@ -190,9 +190,16 @@ func getS3Status(info BucketInfo) (*bucketStatus, error) {
 		Bucket: aws.String(info.BucketName),
 		Key:    aws.String(info.Key),
 	})
+	if !strings.HasSuffix(info.Key, "/") {
+		// Retrying with / at the end
+		answer, err = svc.HeadObject(&s3.HeadObjectInput{
+			Bucket: aws.String(info.BucketName),
+			Key:    aws.String(info.Key + "/"),
+		})
+	}
 	if err != nil {
 		clearSessionCache()
-		return nil, fmt.Errorf("caught error while calling HeadObject on key %s of bucket %s: %w", info.Key, info.BucketName, err)
+		return nil, fmt.Errorf("caught error while calling HeadObject on key %s (with or without slash) of bucket %s: %w", info.Key, info.BucketName, err)
 	}
 
 	return &bucketStatus{


### PR DESCRIPTION
Now that we check for HeadObject more restrictively, this crashes because we can't get the metadata to folders without / at the end

Before the improved HeadObject check, the cache just didn't work for those sources (without a slash) but we didn't know about it. The cache file was just attempted to be written everytime without success but without crashing either