### PR TITLE
Improve log information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ static:
 	staticcheck ./...
 	go mod tidy
 
+pre-commit: fmt static test
+
 codecov:
 	@sh ./scripts/coverage.sh --codecov
 

--- a/config/config.go
+++ b/config/config.go
@@ -323,8 +323,7 @@ func ParseConfigFile(terragruntOptions *options.TerragruntOptions, include Inclu
 			terragruntOptions.Logger.Debugf("Configuration file at %s was modified by gotemplate", include.Path)
 			terragruntOptions.Logger.Tracef("Result:\n%s", configString)
 		} else {
-			terragruntOptions.Logger.Debugf("Configuration file at %s was not modified by gotemplate", include.Path)
-
+			terragruntOptions.Logger.Tracef("Configuration file at %s was not modified by gotemplate", include.Path)
 		}
 	}
 
@@ -386,7 +385,7 @@ func parseConfigString(configString string, terragruntOptions *options.Terragrun
 	}
 
 	terragruntOptions.ImportVariablesMap(config.Inputs, options.ConfigVarFile)
-	terragruntOptions.Logger.Debugf("Loaded configuration\n%v", color.GreenString(fmt.Sprint(terragruntConfigFile)))
+	terragruntOptions.Logger.Tracef("Loaded configuration\n%v", color.GreenString(fmt.Sprint(terragruntConfigFile)))
 
 	if !path.IsAbs(include.Path) {
 		include.Path, _ = filepath.Abs(include.Path)
@@ -517,7 +516,7 @@ func (conf *TerragruntConfig) loadBootConfigs(terragruntOptions *options.Terragr
 					return err
 				}
 				caughtError := err
-				terragruntOptions.Logger.Debugf("Caught error while trying to load bootstrap file, trying parsing it as a variables file: %v", caughtError)
+				terragruntOptions.Logger.Tracef("Caught error while trying to load bootstrap file, trying parsing it as a variables file: %v", caughtError)
 				variables, err := util.LoadVariablesFromSource(bootConfigString, bootstrapFile, terragruntOptions.WorkingDir, false, nil)
 				terragruntOptions.ImportVariablesMap(variables, options.ConfigVarFile)
 				if err != nil {

--- a/config/extension_extra_args.go
+++ b/config/extension_extra_args.go
@@ -105,7 +105,7 @@ func (list TerraformExtraArgumentsList) Filter(source string) (result []string, 
 				if util.FileExists(file) {
 					out = append(out, fmt.Sprintf("-var-file=%s", file))
 				} else {
-					terragruntOptions.Logger.Debugf("Skipping var-file %s as it does not exist", file)
+					terragruntOptions.Logger.Tracef("Skipping var-file %s as it does not exist", file)
 				}
 			}
 		}

--- a/config/extension_import_files.go
+++ b/config/extension_import_files.go
@@ -87,12 +87,12 @@ func (item *ImportFiles) importFiles(folders ...string) (err error) {
 	logger := item.logger()
 
 	if !item.enabled() {
-		logger.Debugf("Import file %s skipped, executed only on %v", item.Name, item.OS)
+		logger.Tracef("Import file %s skipped, executed only on %v", item.Name, item.OS)
 		return
 	}
 
 	if item.Source == "" && len(item.Files) == 0 && len(item.CopyAndRename) == 0 {
-		logger.Debugf("Import file %s skipped, nothing to do", item.Name)
+		logger.Tracef("Import file %s skipped, nothing to do", item.Name)
 		return
 	}
 
@@ -100,6 +100,12 @@ func (item *ImportFiles) importFiles(folders ...string) (err error) {
 	if len(folders) == 0 {
 		folders = []string{item.options().WorkingDir}
 	}
+
+	trimmedFolders := make([]string, len(folders))
+	for i := range trimmedFolders {
+		trimmedFolders[i] = util.GetPathRelativeToMax(folders[i], item.options().WorkingDir, 2)
+	}
+	logger.Infof("%s to %s", item.DisplayName, strings.Join(trimmedFolders, ", "))
 
 	var sourceFolder, sourceFolderPrefix string
 	if sourceFolder, err = item.config().GetSourceFolder(item.Name, item.Source, *item.Required); err != nil {
@@ -177,7 +183,6 @@ func (item *ImportFiles) importFiles(folders ...string) (err error) {
 		}
 
 		for _, pattern := range item.Files {
-			name := pattern
 			if !filepath.IsAbs(pattern) {
 				pattern = filepath.Join(sourceFolder, pattern)
 			}
@@ -211,14 +216,11 @@ func (item *ImportFiles) importFiles(folders ...string) (err error) {
 			}
 			sourceFiles = append(sourceFiles, newFiles...)
 
-			if len(newFiles) == 1 {
-				logger.Debugf("Import file %s%s", util.GetPathRelativeToMax(newFiles[0].source, item.options().WorkingDir, 2), contextMessage)
-			} else {
+			if len(newFiles) > 1 {
 				copiedFiles := make([]string, len(newFiles))
 				for i := range newFiles {
 					copiedFiles[i] = util.GetPathRelativeToMax(newFiles[i].target, item.options().WorkingDir, 2)
 				}
-				logger.Debugf("Import file %s: %s%s", name, strings.Join(copiedFiles, ", "), contextMessage)
 			}
 		}
 

--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -169,7 +169,7 @@ func (list ImportVariablesList) Import() (err error) {
 						return
 					}
 				} else {
-					terragruntOptions.Logger.Debugf("Skipping var-file %s as it does not exist", file)
+					terragruntOptions.Logger.Tracef("Skipping var-file %s as it does not exist", file)
 				}
 			}
 		}

--- a/dynamodb/dynamo_lock_table.go
+++ b/dynamodb/dynamo_lock_table.go
@@ -74,11 +74,11 @@ func createLockTable(tableName string, readCapacityUnits int, writeCapacityUnits
 	terragruntOptions.Logger.Infof("Creating table %s in DynamoDB", tableName)
 
 	attributeDefinitions := []*dynamodb.AttributeDefinition{
-		&dynamodb.AttributeDefinition{AttributeName: aws.String(attrLockID), AttributeType: aws.String(dynamodb.ScalarAttributeTypeS)},
+		{AttributeName: aws.String(attrLockID), AttributeType: aws.String(dynamodb.ScalarAttributeTypeS)},
 	}
 
 	keySchema := []*dynamodb.KeySchemaElement{
-		&dynamodb.KeySchemaElement{AttributeName: aws.String(attrLockID), KeyType: aws.String(dynamodb.KeyTypeHash)},
+		{AttributeName: aws.String(attrLockID), KeyType: aws.String(dynamodb.KeyTypeHash)},
 	}
 
 	_, err := client.CreateTable(&dynamodb.CreateTableInput{

--- a/dynamodb/dynamo_lock_test_utils.go
+++ b/dynamodb/dynamo_lock_test_utils.go
@@ -78,6 +78,6 @@ func withLockTable(t *testing.T, action func(tableName string, client *dynamodb.
 
 func createKeyFromItemID(itemID string) map[string]*dynamodb.AttributeValue {
 	return map[string]*dynamodb.AttributeValue{
-		attrLockID: &dynamodb.AttributeValue{S: aws.String(itemID)},
+		attrLockID: {S: aws.String(itemID)},
 	}
 }

--- a/remote/terraform_state_file_test.go
+++ b/remote/terraform_state_file_test.go
@@ -33,7 +33,7 @@ func TestParseTerraformStateLocal(t *testing.T) {
 		Serial:  0,
 		Backend: nil,
 		Modules: []terraformStateModule{
-			terraformStateModule{
+			{
 				Path:      []string{"root"},
 				Outputs:   map[string]interface{}{},
 				Resources: map[string]interface{}{},
@@ -90,7 +90,7 @@ func TestParseTerraformStateRemote(t *testing.T) {
 			},
 		},
 		Modules: []terraformStateModule{
-			terraformStateModule{
+			{
 				Path:      []string{"root"},
 				Outputs:   map[string]interface{}{},
 				Resources: map[string]interface{}{},
@@ -220,7 +220,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 			},
 		},
 		Modules: []terraformStateModule{
-			terraformStateModule{
+			{
 				Path: []string{"root"},
 				Outputs: map[string]interface{}{
 					"key1": "value1",
@@ -229,7 +229,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 				},
 				Resources: map[string]interface{}{},
 			},
-			terraformStateModule{
+			{
 				Path: []string{"root", "module_with_outputs_no_resources"},
 				Outputs: map[string]interface{}{
 					"key1": "",
@@ -237,7 +237,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 				},
 				Resources: map[string]interface{}{},
 			},
-			terraformStateModule{
+			{
 				Path:    []string{"root", "module_with_resources_no_outputs"},
 				Outputs: map[string]interface{}{},
 				Resources: map[string]interface{}{
@@ -277,7 +277,7 @@ func TestParseTerraformStateRemoteFull(t *testing.T) {
 					},
 				},
 			},
-			terraformStateModule{
+			{
 				Path:      []string{"root", "module_level_1", "module_level_2"},
 				Outputs:   map[string]interface{}{},
 				Resources: map[string]interface{}{},

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -27,6 +27,7 @@ import (
 type CommandContext struct {
 	Stdout, Stderr io.Writer // If these variables are left unset, the default value from current options set will be used
 	DisplayCommand string    // If not specified, the actual command will be displayed
+	LogLevel       logrus.Level
 
 	command             string
 	options             *options.TerragruntOptions
@@ -48,6 +49,7 @@ func NewCmd(options *options.TerragruntOptions, cmd string) *CommandContext {
 		log:        options.Logger,
 		env:        options.EnvironmentVariables(),
 		workingDir: options.WorkingDir,
+		LogLevel:   logrus.DebugLevel,
 	}
 	return &context
 }
@@ -171,9 +173,9 @@ func (c CommandContext) Run() error {
 		}
 
 		if c.DisplayCommand == "" {
-			c.log.Debug(verb, "command: ", filepath.Base(cmd.Args[0]), " ", strings.Join(cmd.Args[1:], " "))
+			c.log.Log(c.LogLevel, verb, "command: ", filepath.Base(cmd.Args[0]), " ", strings.Join(cmd.Args[1:], " "))
 		} else {
-			c.log.Debug(verb, "command: ", c.DisplayCommand)
+			c.log.Log(c.LogLevel, verb, "command: ", c.DisplayCommand)
 		}
 
 		if tempFile != "" {
@@ -202,7 +204,7 @@ func (c CommandContext) Run() error {
 		if finalStatus == nil {
 			break
 		} else {
-			c.log.Debugf("Caught error on command: %s", finalStatus)
+			c.log.Log(c.LogLevel, "Caught error on command:", finalStatus)
 		}
 	}
 

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -240,6 +240,6 @@ func TestTerragruntHookIgnoreError(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, testPath)
 	rootPath := util.JoinPath(tmpEnvPath, testPath)
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan -detailed-exitcode --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), os.Stdout, os.Stderr)
-	assert.Nil(t, err)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), os.Stdout, os.Stderr)
+	assert.Nilf(t, err, "%v", err)
 }

--- a/util/file.go
+++ b/util/file.go
@@ -259,7 +259,7 @@ func getSource(source, pwd string, logf func(level logrus.Level, format string, 
 	}
 
 	if strings.HasPrefix(source, "file://") {
-		logf(logrus.DebugLevel, "Getting files directly (without copy) from %s", source)
+		logf(logrus.TraceLevel, "Getting files directly (without copy) from %s", source)
 		return strings.Replace(source, "file://", "", 1), nil
 	}
 


### PR DESCRIPTION
There is not a big difference between the debug log level and the trace log level. To make it less verbose, I suggest to move some traces from debug to trace.

When we execute a sub-command, we may want to have a different logging level. I changed the code to be able to pass the desired log level.

Some trace in import_files were difficult to read. I simplified them to make them more readable.

There were some map initialization that do not require to specify type (resulting in lint warning). I removed them.

