### PR TITLE
Simplify access to variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ static:
 	staticcheck ./...
 	go mod tidy
 
+pre-commit: fmt static test
+
 codecov:
 	@sh ./scripts/coverage.sh --codecov
 

--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -60,19 +60,19 @@ func (item *ImportVariables) loadVariablesFromFile(file string) error {
 }
 
 func (item *ImportVariables) loadVariables(newVariables map[string]interface{}, source options.VariableSource) {
-	for _, nested := range item.NestedObjects {
-		for k1, v1 := range newVariables {
-			// Simplify the reference to variables in case the key is repeated (ex: project.project.value can be directly acceeded with project.value)
-			if v1, isMap := v1.(map[string]interface{}); isMap {
-				if v2, isMap := v1[k1].(map[string]interface{}); isMap {
-					for k, v := range v2 {
-						if _, exist := v1[k]; !exist {
-							v1[k] = v
-						}
+	for key, value := range newVariables {
+		// Simplify the reference to variables in case the key is repeated (ex: project.project.value can be directly accessed with project.value)
+		if map1, isMap := value.(map[string]interface{}); isMap {
+			if map2, isMap := map1[key].(map[string]interface{}); isMap {
+				for mapKey, mapValue := range map2 {
+					if _, exist := map1[mapKey]; !exist {
+						map1[mapKey] = mapValue
 					}
 				}
 			}
 		}
+	}
+	for _, nested := range item.NestedObjects {
 		imported := newVariables
 		if nested != "" {
 			imported = map[string]interface{}{nested: imported}

--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -61,6 +61,18 @@ func (item *ImportVariables) loadVariablesFromFile(file string) error {
 
 func (item *ImportVariables) loadVariables(newVariables map[string]interface{}, source options.VariableSource) {
 	for _, nested := range item.NestedObjects {
+		for k1, v1 := range newVariables {
+			// Simplify the reference to variables in case the key is repeated (ex: project.project.value can be directly acceeded with project.value)
+			if v1, isMap := v1.(map[string]interface{}); isMap {
+				if v2, isMap := v1[k1].(map[string]interface{}); isMap {
+					for k, v := range v2 {
+						if _, exist := v1[k]; !exist {
+							v1[k] = v
+						}
+					}
+				}
+			}
+		}
 		imported := newVariables
 		if nested != "" {
 			imported = map[string]interface{}{nested: imported}

--- a/test/fixture-variables/import-duplicated-name/main.tf
+++ b/test/fixture-variables/import-duplicated-name/main.tf
@@ -1,0 +1,16 @@
+
+output "direct" {
+  value = var.project.project.hello
+}
+
+output "indirect" {
+  value = var.project.hello
+}
+
+output "direct2" {
+  value = var.alias.project.project.hello
+}
+
+output "indirect2" {
+  value = var.alias.project.hello
+}

--- a/test/fixture-variables/import-duplicated-name/terragrunt.hcl
+++ b/test/fixture-variables/import-duplicated-name/terragrunt.hcl
@@ -1,0 +1,8 @@
+import_variables "test" {
+  required_var_files = ["value.hcl"]
+  nested_under       = ["alias", ""]
+}
+
+export_variables {
+  path = "test.tf"
+}

--- a/test/fixture-variables/import-duplicated-name/value.hcl
+++ b/test/fixture-variables/import-duplicated-name/value.hcl
@@ -1,0 +1,5 @@
+project = {
+  project = {
+    hello = "world"
+  }
+}

--- a/test/fixture-variables/list/main.tf
+++ b/test/fixture-variables/list/main.tf
@@ -1,5 +1,4 @@
 variable "my_list" {
-
   type = list(object({
     var1 = string
     var2 = string

--- a/test/fixture-variables/overwrite-with-file/terragrunt.hcl
+++ b/test/fixture-variables/overwrite-with-file/terragrunt.hcl
@@ -5,11 +5,9 @@ import_variables "test2" {
   ]
 }
 
-// Variables defined in files have a lower priority than those defined explicitely
+// Variables defined in files have a lower priority than those defined explicitly
 import_variables "test" {
-  optional_var_files = [
-    "vars.json",
-  ]
+  optional_var_files = ["vars.json"]
 }
 
 export_variables {

--- a/test/integration_hooks_test.go
+++ b/test/integration_hooks_test.go
@@ -240,6 +240,6 @@ func TestTerragruntHookIgnoreError(t *testing.T) {
 	tmpEnvPath := copyEnvironment(t, testPath)
 	rootPath := util.JoinPath(tmpEnvPath, testPath)
 
-	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan -detailed-exitcode --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), os.Stdout, os.Stderr)
-	assert.Nil(t, err)
+	err := runTerragruntCommand(t, fmt.Sprintf("terragrunt plan --terragrunt-non-interactive --terragrunt-working-dir %s", rootPath), os.Stdout, os.Stderr)
+	assert.Nilf(t, err, "%v", err)
 }

--- a/test/integration_variables_test.go
+++ b/test/integration_variables_test.go
@@ -115,6 +115,16 @@ func TestTerragruntImportVariables(t *testing.T) {
 			project:        "fixture-variables/list_from_inputs",
 			expectedOutput: []string{`example = [{"var1":"value5","var2":"value6"}]`},
 		},
+		// This tests that duplicated structure level can be acceded by skiping one level
+		{
+			project: "fixture-variables/import-duplicated-name",
+			expectedOutput: []string{
+				"\ndirect = world",
+				"\nindirect = world",
+				"\ndirect2 = world",
+				"\nindirect2 = world",
+			},
+		},
 	}
 	for _, test := range tests {
 		tt := test // tt must be unique see https://github.com/golang/go/issues/16586


### PR DESCRIPTION
If a user has a variable that is defined under a project/subproject where project=subproject such as infra.infra, it is more convenient (or less awkward) to be able to access the variable directly through infra.variable instead of infra.infra.variable.