### PR TITLE
Allow regex to fetch files from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ import_variables "name" {
   nester_under           = []            # Optional, define variables under a specific object
   os                     = [list of os]  # Optional, default run on all os, os name are those supported by go, i.e. linux, darwin, windows
   disabled               = false         # Optional, provide a mechanism to temporary disable the import variables block
+  fetch_regex            = ""            # Optional, go-getter optimization. This sets a regex that sorts files to fetch from the sources
 }
 ```
 

--- a/cli/download_source.go
+++ b/cli/download_source.go
@@ -89,7 +89,7 @@ func downloadTerraformSourceIfNecessary(terraformSource *TerraformSource, terrag
 	}
 
 	terragruntOptions.Logger.Debugf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
-	if err := util.GetCopy(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String()); err != nil {
+	if err := util.GetCopy(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), ""); err != nil {
 		return err
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -169,11 +169,11 @@ func (tcf *TerragruntConfigFile) convertToTerragruntConfig(terragruntOptions *op
 
 // GetSourceFolder resolves remote source and returns the local temporary folder
 // If the source is local, it is directly returned
-func (tcf *TerragruntConfigFile) GetSourceFolder(name string, source string, failIfNotFound bool) (string, error) {
+func (tcf *TerragruntConfigFile) GetSourceFolder(name string, source string, failIfNotFound bool, fileRegex string) (string, error) {
 	terragruntOptions := tcf.options
 
 	if source != "" {
-		sourceFolder, err := util.GetSource(source, filepath.Dir(tcf.Path), terragruntOptions.Logger)
+		sourceFolder, err := util.GetSource(source, filepath.Dir(tcf.Path), terragruntOptions.Logger, fileRegex)
 		if err != nil {
 			if failIfNotFound {
 				return "", err
@@ -499,7 +499,7 @@ func (conf *TerragruntConfig) loadBootConfigs(terragruntOptions *options.Terragr
 				bootstrapDir = bootstrapDir + "/"
 			}
 
-			sourcePath, err := util.GetSource(bootstrapDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
+			sourcePath, err := util.GetSource(bootstrapDir, terragruntOptions.WorkingDir, terragruntOptions.Logger, "")
 			if err != nil {
 				return err
 			}

--- a/config/extension_extra_args.go
+++ b/config/extension_extra_args.go
@@ -76,7 +76,7 @@ func (list TerraformExtraArgumentsList) Filter(source string) (result []string, 
 			folders = append(folders, source)
 		}
 
-		if newSource, err := config.GetSourceFolder(arg.Name, arg.Source, len(arg.RequiredVarFiles) > 0); err != nil {
+		if newSource, err := config.GetSourceFolder(arg.Name, arg.Source, len(arg.RequiredVarFiles) > 0, ""); err != nil {
 			return nil, err
 		} else if newSource != "" {
 			folders = []string{newSource}

--- a/config/extension_import_files.go
+++ b/config/extension_import_files.go
@@ -108,7 +108,7 @@ func (item *ImportFiles) importFiles(folders ...string) (err error) {
 	logger.Infof("%s to %s", item.DisplayName, strings.Join(trimmedFolders, ", "))
 
 	var sourceFolder, sourceFolderPrefix string
-	if sourceFolder, err = item.config().GetSourceFolder(item.Name, item.Source, *item.Required); err != nil {
+	if sourceFolder, err = item.config().GetSourceFolder(item.Name, item.Source, *item.Required, ""); err != nil {
 		return err
 	} else if sourceFolder != "" {
 		sourceFolderPrefix = fmt.Sprintf("%s%c", sourceFolder, filepath.Separator)

--- a/config/extension_import_variables.go
+++ b/config/extension_import_variables.go
@@ -25,6 +25,7 @@ type ImportVariables struct {
 	NestedObjects    []string          `hcl:"nested_under,optional"`
 	EnvVars          map[string]string `hcl:"env_vars,optional"`
 	OnCommands       []string          `hcl:"on_commands,optional"`
+	SourceFileRegex  string            `hcl:"source_file_regex,optional"`
 }
 
 func (item ImportVariables) itemType() (result string) {
@@ -121,7 +122,7 @@ func (list ImportVariablesList) Import() (err error) {
 				if source == "" {
 					source = terragruntOptions.WorkingDir
 				}
-				source, err := config.GetSourceFolder(item.Name, source, true)
+				source, err := config.GetSourceFolder(item.Name, source, true, item.SourceFileRegex)
 				if err != nil {
 					folderErrors = append(folderErrors, err)
 					continue

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
+replace github.com/hashicorp/go-getter => github.com/coveord/go-getter v1.5.10
+
 replace github.com/hashicorp/hcl/v2 => github.com/coveord/hcl/v2 v2.7.10

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/coveooss/gotemplate/v3 v3.5.2 h1:BQMHBe/CI8NmqzjxFf2uo2k+yhA9mOMdxMqA
 github.com/coveooss/gotemplate/v3 v3.5.2/go.mod h1:kmrLHvzsEui7u3CHVJ2ev+1OfWtCXLbXiChg4i8m6xU=
 github.com/coveooss/multilogger v0.5.2 h1:HmuMT1RTD0d6tkqrrO9FlUBbp2p7QYbcAR6guszlifc=
 github.com/coveooss/multilogger v0.5.2/go.mod h1:Pw3jXW2Y4KEd+j5vFTTGSAFRX4fIOvJZzDPnvf9dr7U=
+github.com/coveord/go-getter v1.5.10 h1:vqJ8Jwyj9Ye6IhCiwrqL19TE8tTWHRuYRz91Hdb96hM=
+github.com/coveord/go-getter v1.5.10/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/coveord/hcl/v2 v2.7.10 h1:A9ZJQ5yK0wnxnR1gzP60Lmu6zgvBDHCI81gV6/ljYhg=
 github.com/coveord/hcl/v2 v2.7.10/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/coveord/kingpin/v2 v2.3.1 h1:GWdfhOpRbIE+5Bt/hGgDbfWkntsCC5484xFWXaor+sg=

--- a/util/get.go
+++ b/util/get.go
@@ -35,7 +35,7 @@ const (
 //
 // This copy will omit and dot-prefixed files (such as .git/, .hg/) and
 // can't be updated on its own.
-func GetCopy(dst, src string) error {
+func GetCopy(dst, src, fileRegex string) error {
 	// Create the temporary directory to do the real Get to
 	tmpDir, err := ioutil.TempDir("", "tf")
 	if err != nil {
@@ -45,8 +45,12 @@ func GetCopy(dst, src string) error {
 
 	tmpDir = filepath.Join(tmpDir, "module")
 
+	options := []getter.ClientOption{}
+	if fileRegex != "" {
+		options = append(options, getter.WithRegexFileMatcher(fileRegex))
+	}
 	// Get to that temporary dir
-	if err := getter.Get(tmpDir, src); err != nil {
+	if err := getter.Get(tmpDir, src, options...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This tells go-getter to not fetch an entire directory (only files that match the regex)

Import benchmarks with three projects:
Small: 0.917s -> 0.357s
Medium: 2.82s -> 1.13s
Large: 22.1s -> 4.12s

The change to go-getter is this one: https://github.com/hashicorp/go-getter/pull/289
I'll wait for feedback but for the meantime, we can use the fork