### PR TITLE
Display the right command name

### DIFF
--- a/cli/cli_app.go
+++ b/cli/cli_app.go
@@ -584,6 +584,12 @@ func runTerragrunt(terragruntOptions *options.TerragruntOptions) (finalStatus er
 			cmd = cmd.ExpandArgs()
 		}
 
+		if actualCommand.Extra.DisplayName != "" {
+			cmd.DisplayCommand = actualCommand.Extra.DisplayName
+		} else {
+			cmd.DisplayCommand = actualCommand.Extra.Name
+		}
+
 		actualCommand.Command = actualCommand.Extra.ActAs
 	} else {
 		// If the command is 'init', stop here. That's because ConfigureRemoteState above will have already called

--- a/shell/run_shell_cmd.go
+++ b/shell/run_shell_cmd.go
@@ -173,10 +173,9 @@ func (c CommandContext) Run() error {
 		}
 
 		if c.DisplayCommand == "" {
-			c.log.Log(c.LogLevel, verb, "command: ", filepath.Base(cmd.Args[0]), " ", strings.Join(cmd.Args[1:], " "))
-		} else {
-			c.log.Log(c.LogLevel, verb, "command: ", c.DisplayCommand)
+			c.DisplayCommand = filepath.Base(cmd.Args[0])
 		}
+		c.log.Log(c.LogLevel, verb, "command: ", c.DisplayCommand, " ", strings.Join(cmd.Args[1:], " "))
 
 		if tempFile != "" {
 			content, _ := ioutil.ReadFile(tempFile)


### PR DESCRIPTION
When running an extra command, the displayed command should be the display name of the extra command instead of the actual executable.