### PR TITLE
Fix issue where transitive dependencies were required even if ignored

### DIFF
--- a/configstack/module.go
+++ b/configstack/module.go
@@ -329,7 +329,7 @@ func getDependenciesForModule(module *TerraformModule, moduleMap map[string]*Ter
 					}
 				}
 			}
-			if !foundModule {
+			if !foundModule && !module.AssumeAlreadyApplied {
 				err := UnrecognizedDependency{
 					ModulePath:            module.Path,
 					DependencyPath:        dependencyPath,

--- a/test/fixture-modules/module-m/module-m-child/terragrunt.hcl
+++ b/test/fixture-modules/module-m/module-m-child/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/test/fixture-modules/module-m/terragrunt.hcl
+++ b/test/fixture-modules/module-m/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "test"
+}
+
+dependencies {
+  paths = ["./module-m-child"]
+}

--- a/test/fixture-modules/module-n/module-n-child/terragrunt.hcl
+++ b/test/fixture-modules/module-n/module-n-child/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/test/fixture-modules/module-n/terragrunt.hcl
+++ b/test/fixture-modules/module-n/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "test"
+}
+
+dependencies {
+  paths = ["../module-m", "./module-n-child"]
+}


### PR DESCRIPTION
Terragrunt asks the user to either consider a dependency or ignore it if it's not within the working dir
This logic works well for direct dependencies but crashed for transitive dependencies