### PR TITLE
Log the duration of pre and post hooks to allow users to optimize less performant hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# fixtures write `.out` files in their hooks
+*.out
+
 .*.sw?
 .idea
 vendor

--- a/config/config.go
+++ b/config/config.go
@@ -153,13 +153,13 @@ func (tcf *TerragruntConfigFile) convertToTerragruntConfig(terragruntOptions *op
 		}
 	}
 
-	tcf.ExtraArgs.init(tcf)
-	tcf.ExtraCommands.init(tcf)
-	tcf.ImportFiles.init(tcf)
-	tcf.ImportVariables.init(tcf)
-	tcf.ApprovalConfig.init(tcf)
-	tcf.PreHooks.init(tcf)
-	tcf.PostHooks.init(tcf)
+	tcf.ExtraArgs.baseInit(tcf)
+	tcf.ExtraCommands.baseInit(tcf)
+	tcf.ImportFiles.baseInit(tcf)
+	tcf.ImportVariables.baseInit(tcf)
+	tcf.ApprovalConfig.baseInit(tcf)
+	tcf.PreHooks.init(tcf, PreHookType)
+	tcf.PostHooks.init(tcf, PostHookType)
 	tcf.RunConditions = RunConditions{}
 	for _, condition := range tcf.RunConditionsHclDefinition {
 		if !condition.RunIf.IsNull() {
@@ -409,8 +409,6 @@ func parseConfigString(configString string, terragruntOptions *options.Terragrun
 
 	terragruntOptions.ImportVariablesMap(config.Inputs, options.ConfigVarFile)
 	terragruntOptions.Logger.Tracef("Loaded configuration\n%v", color.GreenString(fmt.Sprint(terragruntConfigFile)))
-
-	config.initializeHooks()
 
 	if !path.IsAbs(include.Path) {
 		include.Path, _ = filepath.Abs(include.Path)

--- a/config/config.go
+++ b/config/config.go
@@ -251,6 +251,7 @@ func ReadTerragruntConfig(terragruntOptions *options.TerragruntOptions) (*Terrag
 	include := IncludeConfig{Path: terragruntOptions.TerragruntConfigPath}
 	_, conf, err := ParseConfigFile(terragruntOptions, include)
 	if err == nil {
+		conf.initializeHooks()
 		return conf, nil
 	}
 	switch tgerrors.Unwrap(err).(type) {
@@ -435,6 +436,7 @@ func parseConfigString(configString string, terragruntOptions *options.Terragrun
 	}
 
 	config.mergeIncludedConfig(*includedConfig, terragruntOptions)
+
 	return
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -251,7 +251,6 @@ func ReadTerragruntConfig(terragruntOptions *options.TerragruntOptions) (*Terrag
 	include := IncludeConfig{Path: terragruntOptions.TerragruntConfigPath}
 	_, conf, err := ParseConfigFile(terragruntOptions, include)
 	if err == nil {
-		conf.initializeHooks()
 		return conf, nil
 	}
 	switch tgerrors.Unwrap(err).(type) {
@@ -410,6 +409,8 @@ func parseConfigString(configString string, terragruntOptions *options.Terragrun
 
 	terragruntOptions.ImportVariablesMap(config.Inputs, options.ConfigVarFile)
 	terragruntOptions.Logger.Tracef("Loaded configuration\n%v", color.GreenString(fmt.Sprint(terragruntConfigFile)))
+
+	config.initializeHooks()
 
 	if !path.IsAbs(include.Path) {
 		include.Path, _ = filepath.Abs(include.Path)

--- a/config/extension_base_list.go
+++ b/config/extension_base_list.go
@@ -20,7 +20,7 @@ func IGenericItem(item interface{}) TerragruntExtensioner {
 	return item.(TerragruntExtensioner)
 }
 
-func (list GenericItemList) init(config *TerragruntConfigFile) {
+func (list GenericItemList) baseInit(config *TerragruntConfigFile) {
 	for i := range list {
 		IGenericItem(&list[i]).init(config)
 	}

--- a/config/extension_hook.go
+++ b/config/extension_hook.go
@@ -33,7 +33,7 @@ func (hookType HookType) String() string {
 	case PostHookType:
 		return "post_hook"
 	default:
-		return fmt.Sprintf("(invalid hook type %d!)", hookType)
+		panic(fmt.Sprintf("Could not convert HookType (internal value: %d) to string.", hookType))
 	}
 }
 

--- a/config/extension_hook.go
+++ b/config/extension_hook.go
@@ -176,13 +176,11 @@ func (list HookList) Filter(filter HookFilter) HookList {
 	return result
 }
 
-func (config *TerragruntConfig) initializeHooks() {
-	for idx := range config.PreHooks {
-		config.PreHooks[idx].Type = PreHookType
-	}
+func (hookList HookList) init(config *TerragruntConfigFile, hookType HookType) {
+	hookList.baseInit(config)
 
-	for idx := range config.PostHooks {
-		config.PostHooks[idx].Type = PostHookType
+	for idx := range hookList {
+		hookList[idx].Type = hookType
 	}
 }
 

--- a/config/extension_hook_test.go
+++ b/config/extension_hook_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHookTypeStringConversion(t *testing.T) {
+	testCases := []struct {
+		name           string
+		hookType       HookType
+		expectedString string
+	}{
+		{name: "UnsetHookType", hookType: UnsetHookType, expectedString: "(unset hook type!)"},
+		{name: "PreHookType", hookType: PreHookType, expectedString: "pre_hook"},
+		{name: "PostHookType", hookType: PostHookType, expectedString: "post_hook"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := testCase.hookType.String()
+			assert.Equal(t, testCase.expectedString, actual)
+		})
+	}
+}

--- a/config/generated_approval_config.go
+++ b/config/generated_approval_config.go
@@ -19,7 +19,7 @@ func IApprovalConfig(item interface{}) TerragruntExtensioner {
 	return item.(TerragruntExtensioner)
 }
 
-func (list ApprovalConfigList) init(config *TerragruntConfigFile) {
+func (list ApprovalConfigList) baseInit(config *TerragruntConfigFile) {
 	for i := range list {
 		IApprovalConfig(&list[i]).init(config)
 	}

--- a/config/generated_extra_args.go
+++ b/config/generated_extra_args.go
@@ -19,7 +19,7 @@ func ITerraformExtraArguments(item interface{}) TerragruntExtensioner {
 	return item.(TerragruntExtensioner)
 }
 
-func (list TerraformExtraArgumentsList) init(config *TerragruntConfigFile) {
+func (list TerraformExtraArgumentsList) baseInit(config *TerragruntConfigFile) {
 	for i := range list {
 		ITerraformExtraArguments(&list[i]).init(config)
 	}

--- a/config/generated_extra_command.go
+++ b/config/generated_extra_command.go
@@ -19,7 +19,7 @@ func IExtraCommand(item interface{}) TerragruntExtensioner {
 	return item.(TerragruntExtensioner)
 }
 
-func (list ExtraCommandList) init(config *TerragruntConfigFile) {
+func (list ExtraCommandList) baseInit(config *TerragruntConfigFile) {
 	for i := range list {
 		IExtraCommand(&list[i]).init(config)
 	}

--- a/config/generated_hooks.go
+++ b/config/generated_hooks.go
@@ -19,7 +19,7 @@ func IHook(item interface{}) TerragruntExtensioner {
 	return item.(TerragruntExtensioner)
 }
 
-func (list HookList) init(config *TerragruntConfigFile) {
+func (list HookList) baseInit(config *TerragruntConfigFile) {
 	for i := range list {
 		IHook(&list[i]).init(config)
 	}

--- a/config/generated_import_files.go
+++ b/config/generated_import_files.go
@@ -19,7 +19,7 @@ func IImportFiles(item interface{}) TerragruntExtensioner {
 	return item.(TerragruntExtensioner)
 }
 
-func (list ImportFilesList) init(config *TerragruntConfigFile) {
+func (list ImportFilesList) baseInit(config *TerragruntConfigFile) {
 	for i := range list {
 		IImportFiles(&list[i]).init(config)
 	}

--- a/config/generated_import_variables.go
+++ b/config/generated_import_variables.go
@@ -19,7 +19,7 @@ func IImportVariables(item interface{}) TerragruntExtensioner {
 	return item.(TerragruntExtensioner)
 }
 
-func (list ImportVariablesList) init(config *TerragruntConfigFile) {
+func (list ImportVariablesList) baseInit(config *TerragruntConfigFile) {
 	for i := range list {
 		IImportVariables(&list[i]).init(config)
 	}


### PR DESCRIPTION
Jira: DT-4364

The main goal of this PR is to allow users to find and then eventually fix slow hooks in their terragrunt configuration. Terragrunt hooks are generally run with every invocation.