### PR TITLE
Fix the worker init wait time before running any *-all command

### DIFF
--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -16,6 +16,7 @@ func initWorkers(n int) {
 	if burstyLimiter == nil {
 		burstyLimiter = make(chan int, n)
 		for i := 1; i <= n; i++ {
+			fmt.Println("Adding token", i, "to the channel")
 			burstyLimiter <- i
 			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 		}

--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -16,9 +16,9 @@ func initWorkers(n int) {
 	if burstyLimiter == nil {
 		burstyLimiter = make(chan int, n)
 		for i := 1; i <= n; i++ {
+			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 			fmt.Println("Adding token", i, "to the channel")
 			burstyLimiter <- i
-			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 		}
 	}
 }

--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -16,16 +16,23 @@ func initWorkers(n int) {
 	if burstyLimiter == nil {
 		burstyLimiter = make(chan int, n)
 		for i := 1; i <= n; i++ {
-			fmt.Println("Adding token", i, "to the channel")
+			fmt.Println("#!#!# Adding token", i, "to the channel")
 			burstyLimiter <- i
 			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 		}
 	}
 }
 
-func nbWorkers() int       { return cap(burstyLimiter) }
-func waitWorker() int      { return <-burstyLimiter }
-func freeWorker(token int) { burstyLimiter <- token }
+func nbWorkers() int { return cap(burstyLimiter) }
+func waitWorker() int {
+	id := <-burstyLimiter
+	fmt.Println("#!#!# Removing token", id, "from the channel")
+	return id
+}
+func freeWorker(token int) {
+	fmt.Println("#!#!# Freeing token", token)
+	burstyLimiter <- token
+}
 
 var burstyLimiter chan int
 

--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -16,8 +16,8 @@ func initWorkers(n int) {
 	if burstyLimiter == nil {
 		burstyLimiter = make(chan int, n)
 		for i := 1; i <= n; i++ {
-			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 			burstyLimiter <- i
+			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 		}
 	}
 }

--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -7,8 +7,6 @@ import (
 	"github.com/fatih/color"
 )
 
-const waitTimeBetweenThread = 2500
-
 func initWorkers(n int) {
 	if n <= 0 {
 		panic(fmt.Errorf("the number of workers must be greater than 0 (%d)", n))
@@ -16,23 +14,14 @@ func initWorkers(n int) {
 	if burstyLimiter == nil {
 		burstyLimiter = make(chan int, n)
 		for i := 1; i <= n; i++ {
-			fmt.Println("#!#!# Adding token", i, "to the channel")
 			burstyLimiter <- i
-			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 		}
 	}
 }
 
-func nbWorkers() int { return cap(burstyLimiter) }
-func waitWorker() int {
-	id := <-burstyLimiter
-	fmt.Println("#!#!# Removing token", id, "from the channel")
-	return id
-}
-func freeWorker(token int) {
-	fmt.Println("#!#!# Freeing token", token)
-	burstyLimiter <- token
-}
+func nbWorkers() int       { return cap(burstyLimiter) }
+func waitWorker() int      { return <-burstyLimiter }
+func freeWorker(token int) { burstyLimiter <- token }
 
 var burstyLimiter chan int
 

--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -16,9 +16,9 @@ func initWorkers(n int) {
 	if burstyLimiter == nil {
 		burstyLimiter = make(chan int, n)
 		for i := 1; i <= n; i++ {
-			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 			fmt.Println("Adding token", i, "to the channel")
 			burstyLimiter <- i
+			time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
 		}
 	}
 }

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -113,13 +113,11 @@ func runModulesWithHandler(modules []*TerraformModule, handler ModuleHandler, or
 		return err
 	}
 
-	for _, module := range runningModules {
-		// Starts mechanism that control the maximum number of active workers
-		if module.Module.TerragruntOptions.NbWorkers <= 0 {
-			module.Module.TerragruntOptions.NbWorkers = len(runningModules)
+	if len(modules) != 0 {
+		if modules[0].TerragruntOptions.NbWorkers <= 0 {
+			modules[0].TerragruntOptions.NbWorkers = len(runningModules)
 		}
-		go initWorkers(module.Module.TerragruntOptions.NbWorkers)
-		break
+		initWorkers(modules[0].TerragruntOptions.NbWorkers)
 	}
 
 	var waitGroup sync.WaitGroup
@@ -211,14 +209,10 @@ func (module *runningModule) dependencies() []string {
 
 // Run a module once all of its dependencies have finished executing.
 func (module *runningModule) runModuleWhenReady() {
-	module.Module.TerragruntOptions.Logger.Infof("#!#!# Starting the WAIT FOR DEPENDENCIES for module %s", module.displayName())
 	err := module.waitForDependencies()
 	if err == nil {
-		module.Module.TerragruntOptions.Logger.Infof("#!#!# Starting the WAIT FOR A WORKER for module %s", module.displayName())
 		module.workerID = waitWorker()
-		module.Module.TerragruntOptions.Logger.Infof("#!#!# Captured the worker with id %d for module %s", module.workerID, module.displayName())
 		defer func() { freeWorker(module.workerID) }()
-		module.Module.TerragruntOptions.Logger.Infof("#!#!# Starting the ACTUAL RUN for module %s", module.displayName())
 		err = module.runNow()
 	}
 	module.moduleFinished(err)
@@ -232,9 +226,7 @@ func (module *runningModule) waitForDependencies() error {
 		log.Debugf("Module %s must wait for %s to finish", module.displayName(), strings.Join(module.dependencies(), ", "))
 	}
 	for len(module.Dependencies) > 0 {
-		module.Module.TerragruntOptions.Logger.Infof("#!#!# Still WAITING on dependencies for module %s", module.displayName())
 		doneDependency := <-module.DependencyDone
-		module.Module.TerragruntOptions.Logger.Infof("#!#!# The WAIT FOR dependency %s for module %s done!", doneDependency.displayName(), module.displayName())
 		delete(module.Dependencies, doneDependency.Module.Path)
 
 		depPath := util.GetPathRelativeToWorkingDirMax(doneDependency.Module.Path, 3)

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -118,7 +118,8 @@ func runModulesWithHandler(modules []*TerraformModule, handler ModuleHandler, or
 		if module.Module.TerragruntOptions.NbWorkers <= 0 {
 			module.Module.TerragruntOptions.NbWorkers = len(runningModules)
 		}
-		go initWorkers(module.Module.TerragruntOptions.NbWorkers)
+		// go initWorkers(module.Module.TerragruntOptions.NbWorkers)
+		initWorkers(module.Module.TerragruntOptions.NbWorkers)
 		break
 	}
 

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -118,7 +118,7 @@ func runModulesWithHandler(modules []*TerraformModule, handler ModuleHandler, or
 		if module.Module.TerragruntOptions.NbWorkers <= 0 {
 			module.Module.TerragruntOptions.NbWorkers = len(runningModules)
 		}
-		initWorkers(module.Module.TerragruntOptions.NbWorkers)
+		go initWorkers(module.Module.TerragruntOptions.NbWorkers)
 		break
 	}
 

--- a/configstack/running_module_test.go
+++ b/configstack/running_module_test.go
@@ -12,13 +12,13 @@ import (
 var mockOptions = options.NewTerragruntOptionsForTest("running_module_test")
 
 func TestToRunningModulesNoModules(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	testToRunningModules(t, []*TerraformModule{}, NormalOrder, map[string]*runningModule{})
 }
 
 func TestToRunningModulesOneModuleNoDependencies(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -42,7 +42,7 @@ func TestToRunningModulesOneModuleNoDependencies(t *testing.T) {
 }
 
 func TestToRunningModulesTwoModulesNoDependencies(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -81,7 +81,7 @@ func TestToRunningModulesTwoModulesNoDependencies(t *testing.T) {
 }
 
 func TestToRunningModulesTwoModulesWithDependencies(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -122,7 +122,7 @@ func TestToRunningModulesTwoModulesWithDependencies(t *testing.T) {
 }
 
 func TestToRunningModulesTwoModulesWithDependenciesReverseOrder(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -163,7 +163,7 @@ func TestToRunningModulesTwoModulesWithDependenciesReverseOrder(t *testing.T) {
 }
 
 func TestToRunningModulesMultipleModulesWithAndWithoutDependencies(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -263,7 +263,7 @@ func TestToRunningModulesMultipleModulesWithAndWithoutDependencies(t *testing.T)
 }
 
 func TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -365,14 +365,14 @@ func testToRunningModules(t *testing.T, modules []*TerraformModule, order depend
 }
 
 func TestRunModulesNoModules(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	err := runModules([]*TerraformModule{})
 	assert.Nil(t, err, "Unexpected error: %v", err)
 }
 
 func TestRunModulesOneModuleSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -388,7 +388,7 @@ func TestRunModulesOneModuleSuccess(t *testing.T) {
 }
 
 func TestRunModulesOneModuleAssumeAlreadyRan(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -405,7 +405,7 @@ func TestRunModulesOneModuleAssumeAlreadyRan(t *testing.T) {
 }
 
 func TestRunModulesReverseOrderOneModuleSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -421,7 +421,7 @@ func TestRunModulesReverseOrderOneModuleSuccess(t *testing.T) {
 }
 
 func TestRunModulesOneModuleError(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -438,7 +438,7 @@ func TestRunModulesOneModuleError(t *testing.T) {
 }
 
 func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -455,7 +455,7 @@ func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesNoDependenciesSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -490,7 +490,7 @@ func TestRunModulesMultipleModulesNoDependenciesSuccess(t *testing.T) {
 }
 
 func TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -525,7 +525,7 @@ func TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess(t *testing.T
 }
 
 func TestRunModulesMultipleModulesNoDependenciesOneFailure(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -561,7 +561,7 @@ func TestRunModulesMultipleModulesNoDependenciesOneFailure(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -599,7 +599,7 @@ func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesWithDependenciesSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -634,7 +634,7 @@ func TestRunModulesMultipleModulesWithDependenciesSuccess(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -679,7 +679,7 @@ func TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess(t 
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -714,7 +714,7 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess(t *testing
 }
 
 func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -752,7 +752,7 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErrors(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	terragruntOptionsA := optionsWithMockTerragruntCommand("a", nil, &aRan)
@@ -794,7 +794,7 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErro
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -832,7 +832,7 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *test
 }
 
 func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -871,7 +871,7 @@ func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -933,7 +933,7 @@ func TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess(t *testin
 }
 
 func TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -1009,7 +1009,7 @@ func TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure(t *te
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{

--- a/configstack/running_module_test.go
+++ b/configstack/running_module_test.go
@@ -12,13 +12,13 @@ import (
 var mockOptions = options.NewTerragruntOptionsForTest("running_module_test")
 
 func TestToRunningModulesNoModules(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	testToRunningModules(t, []*TerraformModule{}, NormalOrder, map[string]*runningModule{})
 }
 
 func TestToRunningModulesOneModuleNoDependencies(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -42,7 +42,7 @@ func TestToRunningModulesOneModuleNoDependencies(t *testing.T) {
 }
 
 func TestToRunningModulesTwoModulesNoDependencies(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -81,7 +81,7 @@ func TestToRunningModulesTwoModulesNoDependencies(t *testing.T) {
 }
 
 func TestToRunningModulesTwoModulesWithDependencies(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -122,7 +122,7 @@ func TestToRunningModulesTwoModulesWithDependencies(t *testing.T) {
 }
 
 func TestToRunningModulesTwoModulesWithDependenciesReverseOrder(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -163,7 +163,7 @@ func TestToRunningModulesTwoModulesWithDependenciesReverseOrder(t *testing.T) {
 }
 
 func TestToRunningModulesMultipleModulesWithAndWithoutDependencies(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -263,7 +263,7 @@ func TestToRunningModulesMultipleModulesWithAndWithoutDependencies(t *testing.T)
 }
 
 func TestToRunningModulesMultipleModulesWithAndWithoutDependenciesReverseOrder(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	moduleA := &TerraformModule{
 		Path:              "a",
@@ -365,14 +365,14 @@ func testToRunningModules(t *testing.T, modules []*TerraformModule, order depend
 }
 
 func TestRunModulesNoModules(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	err := runModules([]*TerraformModule{})
 	assert.Nil(t, err, "Unexpected error: %v", err)
 }
 
 func TestRunModulesOneModuleSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -388,7 +388,7 @@ func TestRunModulesOneModuleSuccess(t *testing.T) {
 }
 
 func TestRunModulesOneModuleAssumeAlreadyRan(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -405,7 +405,7 @@ func TestRunModulesOneModuleAssumeAlreadyRan(t *testing.T) {
 }
 
 func TestRunModulesReverseOrderOneModuleSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -421,7 +421,7 @@ func TestRunModulesReverseOrderOneModuleSuccess(t *testing.T) {
 }
 
 func TestRunModulesOneModuleError(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -438,7 +438,7 @@ func TestRunModulesOneModuleError(t *testing.T) {
 }
 
 func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -455,7 +455,7 @@ func TestRunModulesReverseOrderOneModuleError(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesNoDependenciesSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -490,7 +490,7 @@ func TestRunModulesMultipleModulesNoDependenciesSuccess(t *testing.T) {
 }
 
 func TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -525,7 +525,7 @@ func TestRunModulesReverseOrderMultipleModulesNoDependenciesSuccess(t *testing.T
 }
 
 func TestRunModulesMultipleModulesNoDependenciesOneFailure(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -561,7 +561,7 @@ func TestRunModulesMultipleModulesNoDependenciesOneFailure(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -599,7 +599,7 @@ func TestRunModulesMultipleModulesNoDependenciesMultipleFailures(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesWithDependenciesSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -634,7 +634,7 @@ func TestRunModulesMultipleModulesWithDependenciesSuccess(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -679,7 +679,7 @@ func TestRunModulesMultipleModulesWithDependenciesWithAssumeAlreadyRanSuccess(t 
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -714,7 +714,7 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesSuccess(t *testing
 }
 
 func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -752,7 +752,7 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailure(t *testing.T) {
 }
 
 func TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErrors(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	terragruntOptionsA := optionsWithMockTerragruntCommand("a", nil, &aRan)
@@ -794,7 +794,7 @@ func TestRunModulesMultipleModulesWithDependenciesOneFailureIgnoreDependencyErro
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -832,7 +832,7 @@ func TestRunModulesReverseOrderMultipleModulesWithDependenciesOneFailure(t *test
 }
 
 func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	expectedErrA := fmt.Errorf("Expected error for module a")
@@ -871,7 +871,7 @@ func TestRunModulesMultipleModulesWithDependenciesMultipleFailures(t *testing.T)
 }
 
 func TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -933,7 +933,7 @@ func TestRunModulesMultipleModulesWithDependenciesLargeGraphAllSuccess(t *testin
 }
 
 func TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{
@@ -1009,7 +1009,7 @@ func TestRunModulesMultipleModulesWithDependenciesLargeGraphPartialFailure(t *te
 }
 
 func TestRunModulesReverseOrderMultipleModulesWithDependenciesLargeGraphPartialFailure(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	aRan := false
 	moduleA := &TerraformModule{


### PR DESCRIPTION
## Why
This fixes the problem where doing a plan|apply-all on a 1 module project could take about as twice as much.

## What
The problem was in the fact that the initialization of the workers was blocking while it was intended (IMO) to be non-blocking and to let the workers be requested and waited. Instead, the init part blocks the program for 2500ms per worker to be allocated (2500 * ms * 10 workers by default during testing) and then all workers can be started in an instant, defeating the purpose of the function. 

## How
During testing, I found that weird race conditions happened when allocating Workers in a async way (yup, because this never happens right). Since the current behaviour is the same as allocating all then starting all routines, I opted for simply removing the 2500ms sleep between allocations.