### PR TITLE
DT-4467 // New "no changes" string in terraform v1.0.2?

### DIFF
--- a/configstack/stack_plan.go
+++ b/configstack/stack_plan.go
@@ -123,7 +123,8 @@ func warnAboutMissingDependencies(module TerraformModule, output string) {
 func extractSummaryResultFromPlan(output string) (string, int) {
 	const noChangeV012 = "No changes. Infrastructure is up-to-date."
 	const noChangeV013 = "Plan: 0 to add, 0 to change, 0 to destroy."
-	if strings.Contains(output, noChangeV012) || strings.Contains(output, noChangeV013) {
+	const noChangeV102 = "No changes. Your infrastructure matches the configuration."
+	if strings.Contains(output, noChangeV012) || strings.Contains(output, noChangeV013) || strings.Contains(output, noChangeV102) {
 		return "No change", 0
 	}
 

--- a/configstack/stack_plan.go
+++ b/configstack/stack_plan.go
@@ -123,7 +123,7 @@ func warnAboutMissingDependencies(module TerraformModule, output string) {
 func extractSummaryResultFromPlan(output string) (string, int) {
 	const noChangeV012 = "No changes. Infrastructure is up-to-date."
 	const noChangeV013 = "Plan: 0 to add, 0 to change, 0 to destroy."
-	const noChangeV102 = "No changes. Your infrastructure matches the configuration."
+	const noChangeV102 = "Your infrastructure matches the configuration."
 	if strings.Contains(output, noChangeV012) || strings.Contains(output, noChangeV013) || strings.Contains(output, noChangeV102) {
 		return "No change", 0
 	}


### PR DESCRIPTION
https://jenkins-us-east-2.dep.cloud.coveo.com/job/deploy-pipeline-terraform/5901/console

```
15:34:44  No changes. Your infrastructure matches the configuration.
15:34:44  
15:34:44  Terraform has compared your real infrastructure against your configuration
15:34:44  and found no differences, so no changes are needed.
15:34:44  
15:34:44  ------------------------------------------------------------------------------------------------------------------------------------
15:34:44  Summary:
15:34:44      ratlab-service-infrastructure : Unable to determine the plan status
```