### PR TITLE
Stagger module workers start

### DIFF
--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -7,15 +7,20 @@ import (
 	"github.com/fatih/color"
 )
 
+const waitTimeBetweenThread = 500
+
 func initWorkers(n int) {
 	if n <= 0 {
 		panic(fmt.Errorf("the number of workers must be greater than 0 (%d)", n))
 	}
 	if burstyLimiter == nil {
 		burstyLimiter = make(chan int, n)
-		for i := 1; i <= n; i++ {
-			burstyLimiter <- i
-		}
+		go func() {
+			for i := 1; i <= n; i++ {
+				burstyLimiter <- i
+				time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
+			}
+		}()
 	}
 }
 

--- a/configstack/running_limit.go
+++ b/configstack/running_limit.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fatih/color"
 )
 
-const waitTimeBetweenThread = 500
+const progressiveStartDelay = 500 * time.Millisecond
 
 func initWorkers(n int) {
 	if n <= 0 {
@@ -18,7 +18,7 @@ func initWorkers(n int) {
 		go func() {
 			for i := 1; i <= n; i++ {
 				burstyLimiter <- i
-				time.Sleep(waitTimeBetweenThread * time.Millisecond) // Start workers progressively to avoid throttling
+				time.Sleep(progressiveStartDelay) // Start workers progressively to avoid throttling
 			}
 		}()
 	}

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -114,10 +114,12 @@ func runModulesWithHandler(modules []*TerraformModule, handler ModuleHandler, or
 	}
 
 	if len(modules) != 0 {
-		if modules[0].TerragruntOptions.NbWorkers <= 0 {
-			modules[0].TerragruntOptions.NbWorkers = len(runningModules)
+		options := modules[0].TerragruntOptions
+		// We don't gain anything by running on more workers than there are modules
+		if options.NbWorkers <= 0 || options.NbWorkers > len(runningModules) {
+			options.NbWorkers = len(runningModules)
 		}
-		initWorkers(modules[0].TerragruntOptions.NbWorkers)
+		initWorkers(options.NbWorkers)
 	}
 
 	var waitGroup sync.WaitGroup

--- a/configstack/running_module.go
+++ b/configstack/running_module.go
@@ -114,12 +114,12 @@ func runModulesWithHandler(modules []*TerraformModule, handler ModuleHandler, or
 	}
 
 	if len(modules) != 0 {
-		options := modules[0].TerragruntOptions
+		nbWorkers := modules[0].TerragruntOptions.NbWorkers
 		// We don't gain anything by running on more workers than there are modules
-		if options.NbWorkers <= 0 || options.NbWorkers > len(runningModules) {
-			options.NbWorkers = len(runningModules)
+		if nbWorkers <= 0 || nbWorkers > len(runningModules) {
+			nbWorkers = len(runningModules)
 		}
-		initWorkers(options.NbWorkers)
+		initWorkers(nbWorkers)
 	}
 
 	var waitGroup sync.WaitGroup


### PR DESCRIPTION
## _Previously on Terragrunt_
The workers were initiated with sleeps, but synchronously. Which lead to huge wait time => time loss. Then we introduced the _removal_ of the sleep time which led to the same behaviour, but with huge time gains, but it was still synchronous. This defeated the original intent of the code. It was done like this because some weird race condition was reached 1 out of 30 runs which results in a deadlock.

## _Today on Terragrunt_
The reason behind the deadlock was found. The culprit? An async initialization of the channel which staggers the workers. If the modules were to ask for a worker before the routine had time to initialize the staggering channel, they would pull on a `nil` channel and that is a big big nono. Technically, I read it is fine, but in our case, the module just never starts after that. This is a feature and not a bug on Go's side.

### the fix and tldr
To fix the race condition, simply initialize the channel synchronously and fill it asynchronously.
I also changed the number of workers to always be smaller or equal to the number of modules (`len(modules) >= nbWorkers`).

DT-4479