### PR TITLE
Fix bug where negative number of changes were shown

### DIFF
--- a/configstack/stack_plan_test.go
+++ b/configstack/stack_plan_test.go
@@ -1,0 +1,55 @@
+package configstack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractSummaryResultFromPlan(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		planOutput string
+		expected   planSummary
+	}{
+		{
+			name:       "no changes with terraform@0.12",
+			planOutput: "stuff No changes. Infrastructure is up-to-date. stuff",
+			expected:   planSummary{"No change", 0, true},
+		},
+		{
+			name:       "no changes with terraform@0.13",
+			planOutput: "stuff Plan: 0 to add, 0 to change, 0 to destroy. stuff",
+			expected:   planSummary{"No change", 0, true},
+		},
+		{
+			name:       "no changes with terraform@1.0.2",
+			planOutput: "stuff Your infrastructure matches the configuration. stuff",
+			expected:   planSummary{"No change", 0, true},
+		},
+		{
+			name:       "with changes",
+			planOutput: "stuff 11 to add, 10 to change, 21 to destroy. stuff",
+			expected:   planSummary{"11 to add, 10 to change, 21 to destroy.", 42, true},
+		},
+		{
+			name:       "unknown number of changes",
+			planOutput: "Nobody knows ~~ 👻 ~~ Spooky",
+			expected:   planSummary{"Unable to determine the plan status", -1, false},
+		},
+		{
+			name:       "no changes without a plan",
+			planOutput: "stuff SomethingElse: 0 to add, 0 to change, 0 to destroy. stuff",
+			expected:   planSummary{"No effective change", 0, true},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			summary := extractSummaryResultFromPlan(testCase.planOutput)
+			assert.Equal(t, testCase.expected, summary)
+		})
+	}
+}


### PR DESCRIPTION
Jira: DT-4745

The core of this bug comes from cases where we can't determine the number of changes for a plan. Under the hood, when that happens we return `-1`. Later on, when we aggregate all the changes from all the plans we don't consider that we may have failed to determine the number of changes for a plan. Because of that, we sum up the `-1` from earlier leading to negative changes.

This PR stores if we know the changes for a plan and uses that later to generate the right amount. On top of that, it adds a message that lets users know that we weren't able to determine the number of changes for some modules.