### PR TITLE
Pull all commits when releasing

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,10 +15,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-        id: go
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # We need the whole history so that goreleaser can figure out the changes
+          fetch-depth: 0
 
       - name: Install Terraform
         run: |


### PR DESCRIPTION
See https://github.com/goreleaser/goreleaser-action#workflow

By default gh actions only gets the latest commit which doesn't work with goreleaser since it reads the git history to come up with the changelog.