### PR TITLE
fix permissions on the job

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,6 +8,9 @@ jobs:
     name: Build
     permissions:
       id-token: write # required for AWS assume role
+      # This is because the permission block is replacive instead of additive so setting
+      #   id-token removes any other permissions the job has and goreleaser need to write contents
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write # required for AWS assume role
       # This is because the permission block is replacive instead of additive so setting
-      #   id-token removes any other permissions the job has and goreleaser need to write contents
+      # id-token removes any other permissions the job has and goreleaser need to write contents
       contents: write
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This is because the permission block is replacive instead of additive so setting id-token removes any other permissions the job has and goreleaser need to write contents

https://github.com/actions/checkout/issues/254#issuecomment-981945812