### PR TITLE
Fix goreleaser config and revamp repo

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.17
+          go-version: '1.18'
 
       - uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         with:
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.17
+          go-version: '1.18'
 
       - uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,17 +3,16 @@ on:
   pull_request:
     branches:
       - master
+      - main
+
 jobs:
   static:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
-
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Run static checks
         run: make static
@@ -21,26 +20,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
-
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - run: make build
 
   fmt-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
-
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - run: make fmtcheck
 
@@ -56,9 +49,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
-
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Install Terraform
         run: |
@@ -66,3 +57,44 @@ jobs:
           sudo unzip -o -d /usr/local/bin/ /tmp/terraform.zip
 
       - run: make test
+
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.17
+
+      - uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check
+
+  goreleaser-test-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # goreleaser needs the whole history to build the release notes
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.17
+
+      - uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --clean
+        env:
+          CGO_ENABLED: 0
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: test-release
+          path: |
+            dist/*.zip
+            dist/*.txt
+          if-no-files-found: error
+          retention-days: 5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,8 +87,6 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --snapshot --clean
-        env:
-          CGO_ENABLED: 0
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -32,7 +32,7 @@ jobs:
           wget https://releases.hashicorp.com/terraform/${{ matrix.terraform }}/terraform_${{ matrix.terraform }}_linux_amd64.zip -O /tmp/terraform.zip
           sudo unzip -o -d /usr/local/bin/ /tmp/terraform.zip
 
-      - uses: coveooss/configure-aws-credentials-action@v1.7.0
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::043612128888:role/nrd-oss-terragrunt-github-actions-ci

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,14 +18,17 @@ universal_binaries:
 archives:
   - format: zip
 
-    replacements:
-      amd64: 64-bits
-      darwin: macOS
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}macOS_
+      {{- else }}{{ .Os }}_{{ end }}
+      {{- if eq .Arch "amd64" }}64-bits
+      {{- else }}{{ .Arch }}{{ end }}
 
     files:
       - nothing.*
 
 # GitHub release customization
 release:
-  draft: true
-  prerelease: true
+  prerelease: auto

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coveooss/dev-tooling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Release procedure
+
+1. Find the latest tag
+1. Look at changes between now and the current tag
+1. Create a tag with the format `vX.Y.Z`
+
+    You might be tempted to create a release through GitHub to create the tag.
+    Don't do that. We have a GitHub workflow in place that will create a release
+    from tags that get pushed. Create your tag with `git tag`.
+
+1. Push that tag
+1. Wait for the [Release on Tag](https://github.com/coveooss/tgf/actions/workflows/tag.yml) to build your release.
+1. Find your release and make sure things are as you expect them to be

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,5 @@
     from tags that get pushed. Create your tag with `git tag`.
 
 1. Push that tag
-1. Wait for the [Release on Tag](https://github.com/coveooss/tgf/actions/workflows/tag.yml) to build your release.
+1. Wait for the [Release on Tag](https://github.com/coveooss/terragrunt/actions/workflows/tag.yml) to build your release.
 1. Find your release and make sure things are as you expect them to be

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Terragrunt
 
-[![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_terragrunt)
 [![Go Report Card](https://goreportcard.com/badge/github.com/coveooss/terragrunt)](https://goreportcard.com/report/github.com/coveooss/terragrunt)
 [![GoDoc](https://godoc.org/github.com/coveooss/terragrunt?status.svg)](https://godoc.org/github.com/coveooss/terragrunt)
-![Terraform Version](https://img.shields.io/badge/tf-%3E%3D0.12.0-blue.svg)
 
 Terragrunt is a thin wrapper for [Terraform](https://www.terraform.io/) that provides extra tools for keeping your
 Terraform configurations [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself),
@@ -97,9 +95,9 @@ It is possible to set conditions that must be met in order for a project to be e
 
 * All conditions within a `condition` attribute must be true to apply the rule (logical `AND` between elements).
 * Only one `run_conditions` must be True to apply the rule (logical `OR` between elements)
-* If any block marked `ignore_if_true` is true, the code is not executed (logical `OR` between elements).  
-* If any block *NOT* marked `ignore_if_true` is true, the code is executed (logical `OR` between element).  
-* *Important: `ignore_if_true` blocks always take precedence over those that aren't* 
+* If any block marked `ignore_if_true` is true, the code is not executed (logical `OR` between elements).
+* If any block *NOT* marked `ignore_if_true` is true, the code is executed (logical `OR` between element).
+* *Important: `ignore_if_true` blocks always take precedence over those that aren't*
 
 ```hcl
 run_conditions {
@@ -117,12 +115,12 @@ run_conditions {
 }
 ```
 
-The condition for this project to run would be as follows:  
+The condition for this project to run would be as follows:
 `region in ["us-east-1", "us-west-2"] AND another_var in ["value"] AND my_map.my_var in ["value"] AND env not in ["qa"]`
 
-The conditions are evaluated using variables passed to terragrunt/terraform and the accepted or rejected values must be in the form of a list.  
-Any non existing variable will cause an error and the project will be ignored.  
-For more complex situation, it is possible to use variable interpolation as the key:  
+The conditions are evaluated using variables passed to terragrunt/terraform and the accepted or rejected values must be in the form of a list.
+Any non existing variable will cause an error and the project will be ignored.
+For more complex situation, it is possible to use variable interpolation as the key:
 
 ```hcl
 run_conditions {
@@ -352,7 +350,7 @@ uniqueness_criteria = "${var.env}${var.region}/${var.project}"
 There are various ways to import variables such as `inputs` in the terragrunt config or `import_variables` blocks but these variables are
 not accessible by Terraform directly
 
-To write your imported variables to a file, use the `export_variables` block. Example:  
+To write your imported variables to a file, use the `export_variables` block. Example:
 
 ```hcl
 export_variables {


### PR DESCRIPTION
My initial goal here was to stop using the fork of the `aws-actions/configure-aws-credentials` but it turns out that goreleaser was broken and some things were not quite right. The changes are well separated per commits. Reading the commit titles should give you an idea of what the changes are.