### PR TITLE
Revert the goreleaser-action to last approved digest

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,7 +74,7 @@ jobs:
           go-version: ${{ env.GoVersion }}
           cache: false
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -91,7 +91,7 @@ jobs:
           go-version: ${{ env.GoVersion }}
           cache: false
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -45,7 +45,7 @@ jobs:
           make full-test
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
This pull request updates the version of the GoReleaser action used in GitHub workflows to a specific commit hash for better stability and consistency.

### Updates to GitHub workflows:

* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L77-R77): Updated GoReleaser action from `v6` to `7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8` to ensure a specific version is used. [[1]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L77-R77) [[2]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L94-R94)
* [`.github/workflows/tag.yml`](diffhunk://#diff-84dff8d1094ca39c02ac0e48d951ca22f4da29c76b50ae517f5bd2d50f94c2f6L48-R48): Updated GoReleaser action from `v6` to `7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8` to ensure a specific version is used.