### PR TITLE
Fix an error when trying to load default variables

### DIFF
--- a/util/terraform_test.go
+++ b/util/terraform_test.go
@@ -17,7 +17,8 @@ func TestLoadDefaultValues(t *testing.T) {
 		wantResult map[string]interface{}
 		err        string
 	}{
-		{"All Types",
+		{
+			"All Types",
 			testFixtureDefaultValues,
 			map[string]interface{}{
 				"a":               "A (a.tf)",
@@ -34,7 +35,6 @@ func TestLoadDefaultValues(t *testing.T) {
 			},
 			"",
 		},
-		{"Invalid Folder", "Invalid", nil, "Module directory Invalid does not exist or cannot be read"},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I simply removed a lot of code that was handling error recovery. The new library we use returns the desired values even if there are error in the code. So, there is no need to try the whole retry process.

# Generated

This pull request includes several changes to the `util/terraform.go` file, primarily aimed at simplifying the code and removing unnecessary functionality. The most important changes include the removal of unused imports, the elimination of redundant retry logic, and the deletion of the `createTerraformVariablesTemporaryFolder` function. Additionally, minor adjustments were made to the test cases in `util/terraform_test.go`.

Code simplification and cleanup:

* Removed unused imports `path`, `regexp`, and `utils` from `util/terraform.go`.
* Removed the `reTfVariables` regex and the `isOverride` function, as they are no longer needed. [[1]](diffhunk://#diff-26b00c4551d65d800778f665069b00e8f2984eb64aa7642cfc32b31be2561ae7L32-R29) [[2]](diffhunk://#diff-26b00c4551d65d800778f665069b00e8f2984eb64aa7642cfc32b31be2561ae7L206-L279)
* Simplified the `loadDefaultValues` function by removing the retry mechanism and associated temporary folder creation logic. [[1]](diffhunk://#diff-26b00c4551d65d800778f665069b00e8f2984eb64aa7642cfc32b31be2561ae7L177-R172) [[2]](diffhunk://#diff-26b00c4551d65d800778f665069b00e8f2984eb64aa7642cfc32b31be2561ae7L165-R161)

Test adjustments:

* Updated the `TestLoadDefaultValues` function in `util/terraform_test.go` to remove the test case for an invalid folder, which is no longer applicable.