### PR TITLE
Fix code scanning alert no. 4: Incomplete regular expression for hostnames

### DIFF
--- a/awshelper/s3.go
+++ b/awshelper/s3.go
@@ -61,10 +61,10 @@ func formatS3Path(bucket, region string, parts ...string) string {
 func GetBucketObjectInfoFromURL(url string) (*BucketInfo, error) {
 	if s3Patterns == nil {
 		s3Patterns = []*regexp.Regexp{
-			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?).s3.amazonaws.com(?:/(?P<key>.*))?$`),
-			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?).s3-(?P<region>.*?).amazonaws.com(?:/(?P<key>.*))?$`),
-			regexp.MustCompile(`^(s3::)?https?://s3.amazonaws.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
-			regexp.MustCompile(`^(s3::)?https?://s3-(?P<region>.*?).amazonaws\.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
+			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?)\.s3\.amazonaws\.com(?:/(?P<key>.*))?$`),
+			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?)\.s3-(?P<region>.*?)\.amazonaws\.com(?:/(?P<key>.*))?$`),
+			regexp.MustCompile(`^(s3::)?https?://s3\.amazonaws\.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
+			regexp.MustCompile(`^(s3::)?https?://s3-(?P<region>.*?)\.amazonaws\.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
 		}
 	}
 

--- a/awshelper/s3.go
+++ b/awshelper/s3.go
@@ -64,7 +64,7 @@ func GetBucketObjectInfoFromURL(url string) (*BucketInfo, error) {
 			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?).s3.amazonaws.com(?:/(?P<key>.*))?$`),
 			regexp.MustCompile(`^https?://(?P<bucket>[^/\.]+?).s3-(?P<region>.*?).amazonaws.com(?:/(?P<key>.*))?$`),
 			regexp.MustCompile(`^(s3::)?https?://s3.amazonaws.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
-			regexp.MustCompile(`^(s3::)?https?://s3-(?P<region>.*?).amazonaws.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
+			regexp.MustCompile(`^(s3::)?https?://s3-(?P<region>.*?).amazonaws\.com/(?P<bucket>[^/\.]+?)(?:/(?P<key>.*))?$`),
 		}
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/coveooss/terragrunt/security/code-scanning/4](https://github.com/coveooss/terragrunt/security/code-scanning/4)

To fix the problem, we need to escape the dot before `amazonaws.com` in the regular expression. This will ensure that the dot is treated as a literal character and not as a wildcard that can match any character. We can use a raw string literal to avoid having to escape backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
