### PR TITLE
feat: migrate to RunsOn pool= format

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '34 11 * * 3'
 
@@ -26,7 +26,11 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     permissions:
       actions: read
       contents: read
@@ -35,50 +39,52 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ['go']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
 
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: coveo-platform/setup-runner@v1.1.1
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Initialize CodeQL
+        # Initializes the CodeQL tools for scanning.
+        uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+      - name: Autobuild
+        # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+        # If this step fails, then you should remove it and run the build manually (see below)
+        uses: github/codeql-action/autobuild@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Perform CodeQL Analysis
+        # ℹ️ Command-line programs to run using the OS shell.
+        # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+        #   If the Autobuild fails above, remove it and uncomment the following three lines.
+        #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+        # - run: |
+        #     echo "Run, Build Application using script"
+        #     ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
-      with:
-        category: "/language:${{matrix.language}}"
+        uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,8 +28,8 @@ jobs:
     name: Analyze
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__default_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     permissions:
       actions: read
@@ -64,7 +64,6 @@ jobs:
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
-
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
@@ -77,10 +76,8 @@ jobs:
       - name: Perform CodeQL Analysis
         # ℹ️ Command-line programs to run using the OS shell.
         # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
         #   If the Autobuild fails above, remove it and uncomment the following three lines.
         #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
         # - run: |
         #     echo "Run, Build Application using script"
         #     ./location_of_script_within_repo/buildscript.sh

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,13 +12,17 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-
+      - uses: coveo-platform/setup-runner@v1.1.1
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: 'Dependency Review'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,8 +14,8 @@ jobs:
   dependency-review:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__small_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,56 +11,81 @@ permissions:
 
 jobs:
   static:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GoVersion }}
           cache: false
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run static checks
         run: make static
 
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GoVersion }}
           cache: false
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - run: make build
 
   fmt-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GoVersion }}
           cache: false
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - run: make fmt
 
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_x64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     strategy:
       matrix:
         terraform:
@@ -72,6 +97,8 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
+
+      - uses: coveo-platform/setup-runner@v1.1.1
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -88,14 +115,21 @@ jobs:
       - run: make test
 
   goreleaser-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GoVersion }}
@@ -108,16 +142,23 @@ jobs:
           args: check
 
   goreleaser-test-release:
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
 
+      - uses: coveo-platform/setup-runner@v1.1.1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # goreleaser needs the whole history to build the release notes
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GoVersion }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,8 +13,8 @@ jobs:
   static:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__small_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner
@@ -37,8 +37,8 @@ jobs:
   build:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__small_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner
@@ -60,8 +60,8 @@ jobs:
   fmt-check:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__small_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner
@@ -83,8 +83,8 @@ jobs:
   test:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_x64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__default_ubuntu_24_x64
+      - env=cip-dev-v3
       - region=us-east-1
     strategy:
       matrix:
@@ -117,8 +117,8 @@ jobs:
   goreleaser-check:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__small_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__small_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner
@@ -144,8 +144,8 @@ jobs:
   goreleaser-test-release:
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__default_ubuntu_24_arm64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__default_ubuntu_24_arm64
+      - env=cip-dev-v3
       - region=us-east-1
     steps:
       - name: Harden Runner

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,11 @@ jobs:
       # This is because the permission block is replacive instead of additive so setting
       # id-token removes any other permissions the job has and goreleaser need to write contents
       contents: write
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - pool=${{ vars.RUNS_ON_ENV_DEV }}__large_ubuntu_24_x64
+      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - region=us-east-1
     strategy:
       matrix:
         terraform: ["1.9.7"]
@@ -23,6 +27,8 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
+
+      - uses: coveo-platform/setup-runner@v1.1.1
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,8 +16,8 @@ jobs:
       contents: write
     runs-on:
       - runs-on=${{ github.run_id }}
-      - pool=${{ vars.RUNS_ON_ENV_DEV }}__large_ubuntu_24_x64
-      - env=${{ vars.RUNS_ON_ENV_DEV }}
+      - pool=cip-dev-v3__large_ubuntu_24_x64
+      - env=cip-dev-v3
       - region=us-east-1
     strategy:
       matrix:


### PR DESCRIPTION
Migrates runs-on labels to the standard `pool=` format.

## Changes

### `codeql.yml`

- **analyze**: `ubuntu-latest` → `default_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → default_
  - _rationale: CodeQL autobuild for Go is arch-agnostic; schedule-triggered = conservative sizing with default_

### `dependency-review.yml`

- **dependency-review**: `ubuntu-latest` → `small_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → small_
  - _rationale: lightweight dependency review scan, no x64 dependency_

### `pr.yml`

- **static**: `ubuntu-latest` → `small_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → small_
  - _rationale: Go static checks are arch-agnostic and lightweight_
- **build**: `ubuntu-latest` → `small_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → small_
  - _rationale: Go build is arch-agnostic and lightweight_
- **fmt-check**: `ubuntu-latest` → `small_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → small_
  - _rationale: Go fmt check is trivial_
- **test**: `ubuntu-latest` → `default_ubuntu_24_x64`
  - _size: GitHub-hosted → default_
  - _rationale: downloads terraform linux_amd64 binary — must remain x64_
- **goreleaser-check**: `ubuntu-latest` → `small_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → small_
  - _rationale: goreleaser config validation only_
- **goreleaser-test-release**: `ubuntu-latest` → `default_ubuntu_24_arm64`
  - _arch: x64 → arm64_
  - _size: GitHub-hosted → default_
  - _rationale: goreleaser snapshot build is arch-agnostic; default size for build workload_

### `tag.yml`

- **build**: `ubuntu-latest` → `large_ubuntu_24_x64`
  - _size: GitHub-hosted → large_
  - _rationale: full test suite + goreleaser release; downloads terraform linux_amd64 → must be x64; large for release build workload_

## Notes

- setup-runner added to all jobs
- Formatted with yamlfmt
- [Migration guide](https://devportal.dep.cloud.coveo.com/docs/default/component/runs-on/migration/)